### PR TITLE
Add html_safe to markdown method for content

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
+# rubocop:disable Rails/OutputSafety
 module ApplicationHelper
   def markdown(source)
-    Kramdown::Document.new(source.to_s).to_html
+    Kramdown::Document.new(source.to_s).to_html.html_safe
   end
 end
+# rubocop:enable Rails/OutputSafety


### PR DESCRIPTION
`Bugfix`: adding in `html_safe` method in `ApplicationHelper` `markdown` method. 
This will reset the FAQ content to proper markdown again.
Disabled rubocop warning on `html_safe` in `markdown` method.