### PR TITLE
Fix calls to the pr_service in User protected methods

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,12 +49,12 @@ class User < ApplicationRecord
 
   def eligible_pull_requests_count
     pr_service = PullRequestService.new(self)
-    pr_service.score
+    pr_service.eligible_prs.count
   end
 
   def mature_pull_requests_count
     pr_service = PullRequestService.new(self)
-    pr_service.count_mature_prs
+    pr_service.matured_prs.count
   end
 
   def sufficient_eligible_prs?


### PR DESCRIPTION
This should have been done in the PR where the pr_service was refactored and the old methods were removed / repurposed,

Small change to fix this

Was not caught in tests since protected methods are often stubbed rather than tested