### PR TITLE
Add TryUserTransitionService

### DIFF
--- a/app/services/try_user_transition_service.rb
+++ b/app/services/try_user_transition_service.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module TryUserTransitionService
+  def self.call(user)
+    case user.state
+    when 'registered'
+      TryUserTransitionFromRegisteredService.call(user)
+    when 'waiting'
+      TryUserTransitionFromWaitingService.call(user)
+    end
+  end
+end

--- a/spec/services/try_user_transition_service_spec.rb
+++ b/spec/services/try_user_transition_service_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'TryUserTransitionService' do
+  describe '.call' do
+    context 'The user is in the registered state' do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        allow(user).to receive(:eligible_pull_requests_count).and_return(4)
+      end
+
+      it 'calls the appropriate service' do
+        expect(TryUserTransitionFromRegisteredService)
+          .to receive(:call).and_return(true)
+
+        TryUserTransitionService.call(user)
+      end
+    end
+
+    context 'The user is in the waiting state' do
+      let(:user) { FactoryBot.create(:user, :waiting) }
+
+      before do
+        allow(user).to receive(:mature_pull_requests_count).and_return(4)
+      end
+
+      it 'calls the appropriate service' do
+        expect(TryUserTransitionFromWaitingService)
+          .to receive(:call).and_return(true)
+
+        TryUserTransitionService.call(user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the `TryUserTransitionService`, which, depending on a user's state, will call either the `TryUserTransitionFromRegisteredService` or the `TryUserTransitionFromWaitingService`

Passing tests included