### PR TITLE
WIP for fetching just cursors for issues from the Github API

### DIFF
--- a/app/services/hacktoberfest_project_cursor_fetcher.rb
+++ b/app/services/hacktoberfest_project_cursor_fetcher.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+require 'pp'
+
+class HacktoberfestProjectCursorFetcher
+  NODE_LIMIT = 100
+
+  CURSOR_QUERY = <<~GRAPHQL
+    query FindHacktoberfestIssues($queryString: String!, $cursor: String) {
+      rateLimit {
+        cost
+        limit
+        remaining
+        resetAt
+      }
+      search(query: $queryString, type: ISSUE, first: 100, after: $cursor) {
+        issueCount
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
+    }
+  GRAPHQL
+
+  attr_reader :cursors
+
+  def initialize(api_client:)
+    @api_client = api_client
+    @started = false
+    @complete = false
+    @last_cursor = nil
+    @errors = nil
+    @cursors = []
+  end
+
+  def fetch!
+    while fetching_incomplete?
+      @started = true
+      fetch_next_page
+    end
+    pp @cursors
+  end
+
+  private
+
+  def fetching_incomplete?
+    !@started || @has_next_page
+  end
+
+  def fetch_next_page
+    variables = {
+      queryString: 'state:open label:hacktoberfest',
+      cursor: @last_cursor
+    }
+    response = @api_client.request(CURSOR_QUERY, variables)
+
+    pp response
+    if response_returns_expected_error?(response)
+      @has_next_page = false
+    elsif response_invalid?(response)
+      raise HacktoberfestProjectFetcherError.new(
+        'Invalid response received',
+        errors: @errors,
+      )
+    else
+      search = response['data']['search']
+      @has_next_page = search['pageInfo']['hasNextPage']
+      @last_cursor = search['pageInfo']['endCursor']
+      @cursors << @last_cursor
+      pp @last_cursor
+    end
+  end
+
+  def response_returns_expected_error?(response)
+    if response['errors'].present? && response['errors'].size == 1
+      response['errors'].first['message'].include?(
+        'Something went wrong while executing your query. This is most likely a GitHub bug.'
+      )
+    end
+  end
+
+  def response_invalid?(response)
+    @errors = response['errors'] if response['errors'].present?
+    response['data'].blank?
+  end
+end

--- a/lib/tasks/github.rake
+++ b/lib/tasks/github.rake
@@ -10,6 +10,20 @@ end
 
 namespace :github do
   desc 'Fetch and import Hacktoberfest projects'
+  task fetch_and_import_hacktoberfest_projects2: :environment do
+    begin
+      access_token = ENV.fetch('GITHUB_ACCESS_TOKEN')
+      api_client = GithubGraphqlApiClient.new(access_token: access_token)
+      fetcher = HacktoberfestProjectCursorFetcher.new(api_client: api_client)
+      fetcher.fetch!
+    rescue HacktoberfestProjectFetcherError => fetch_error
+      log_error(fetch_error.message)
+    rescue StandardError => unknown_error
+      log_error(unknown_error.message)
+    end
+  end
+
+  desc 'Fetch and import Hacktoberfest projects'
   task fetch_and_import_hacktoberfest_projects: :environment do
     begin
       access_token = ENV.fetch('GITHUB_ACCESS_TOKEN')


### PR DESCRIPTION
This PR is not intended to be merged, but keep track of work already done towards breaking the project import task into many works.

This was done when I thought the github API returned more than 1000 results and
we would need to break the import task into many background jobs. This fetches a
list of cursors from the search results, which we can then send to unique jobs
to fetch the total issues. This will be useful if our import process proves to
be unreliable and needs to be decomposed into separate jobs