### PR TITLE
Fix user transition job spec

### DIFF
--- a/spec/jobs/user_transition_job_spec.rb
+++ b/spec/jobs/user_transition_job_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe UserTransitionJob, type: :job do
 
   it 'tries to transition the user' do
     expect(TryUserTransitionService).to receive(:call).once.with(user)
-    UserTransitionJob.perform_now(user)
+    UserTransitionJob.perform_now(user.id)
   end
 end


### PR DESCRIPTION
Fixes a small but breaking error in the user transition job spec. Was sending in the user to the job, job expects only the id