### PR TITLE
Fix dev link

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -24,7 +24,7 @@
     <div class="footer-end">
       <div class="footer-logos">
       <a href="https://www.digitalocean.com"><img src="<%= asset_path('do-footer-logo.svg') %>"></a>
-      <a href="https://www.digitalocean.com"><img src="<%= asset_path('dev-footer-logo.svg') %>"></a>
+      <a href="https://www.dev.to"><img src="<%= asset_path('dev-footer-logo.svg') %>"></a>
       </div>
       <p>© 2019 DigitalOcean, LLC. All rights reserved.</p>
     </div>


### PR DESCRIPTION
Fixes the dev link 

<img width="711" alt="image" src="https://user-images.githubusercontent.com/7976757/65397505-a546a900-dd7e-11e9-8e18-45dc92c2f371.png">

Of note is that these links don't open in new tabs. just the current tab - not sure if that's what we want anyway