### PR TITLE
Use Redis for Rails cache

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ module Hacktoberfest
     config.assets.paths << Rails.root.join('app', 'assets', 'fonts')
     config.assets.paths << Rails.root.join('vendor', 'assets', 'javascripts')
     config.active_job.queue_adapter = :sidekiq
+    config.cache_store = :redis_store, ENV['REDIS_CACHE_URL']
     config.require_master_key = false
   end
 end


### PR DESCRIPTION
Resolves #101 

This sets up the Rails cache to use a Redis database specified by `REDIS_CACHE_URL`.

It's important to note that the Rails cache relies on Redis to expire items from the cache. So this Redis database must be set up with an LRU cache per https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-rediscachestore:

> Deployment note: Redis doesn't expire keys by default, so take care to use a dedicated Redis cache server. Don't fill up your persistent-Redis server with volatile cache data! Read the Redis cache server setup guide in detail.
