### PR TITLE
Add link to Browse more button and add link to Featured Event blocks

### DIFF
--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -127,7 +127,7 @@
     <!-- FEATURED EVENTS GENERATED HERE -->
     <section class="eventUnion">
       <% @meetups.map do |m| %>
-      <a href="">
+      <a href="<%= m["Event URL"] %>">
         <div class="box">
           <span class="eventMonth">
             <% formatted_date= DateTime.parse(m["Event Start Date/Time"]).to_formatted_s(:long).split(" ") %>


### PR DESCRIPTION
Add link for hacktoberfest repos to "Browse more on Github" button on homepage. Issue #107 

Add specific event link to each featured event block on the homepage. Issue #109 