### PR TITLE
Add ability to impersonate users in non-production environments

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -28,6 +28,17 @@ class SessionsController < ApplicationController
     redirect_to '/'
   end
 
+  def impersonate
+    if Rails.env.production?
+      raise ActionController::RoutingError, 'Not Found'
+    else
+      if @user = User.find_by_id(params[:id])
+        session[:current_user_id] = @user.id
+      end
+      redirect_to '/'
+    end
+  end
+
   protected
 
   def auth_hash

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,4 +25,8 @@ Rails.application.routes.draw do
       ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))
   end if Rails.env.production?
   mount Sidekiq::Web, at: "/sidekiq" unless Rails.env.production? && ENV["SIDEKIQ_PASSWORD"].blank?
+
+  unless Rails.env.production?
+    get '/impersonate/:id', to: 'sessions#impersonate', as: :impersonate
+  end
 end

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -84,4 +84,35 @@ RSpec.describe SessionsController, type: :request do
       end
     end
   end
+
+  describe 'impersionation' do
+    let(:user) { FactoryBot.create(:user) }
+
+    context 'the app is in production mode' do
+      before { allow(Rails).to receive(:env) { "production".inquiry } }
+
+      it 'returns a 404' do
+        expect{ get impersonate_path(user) }.
+          to raise_error(ActionController::RoutingError)
+      end
+    end
+
+    context 'the app is in development mode' do
+      before { allow(Rails).to receive(:env) { "development".inquiry } }
+
+      it 'impersonates the user' do
+        get impersonate_path(user)
+        expect(session[:current_user_id]).to eq(user.id)
+      end
+
+      context 'the user does not exist' do
+        let(:user) { FactoryBot.build(:user) }
+
+        it 'does nothing' do
+          get '/impersonate/0'
+          expect(session[:current_user_id]).to eq(nil)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
For testing purposes, add a route `/impersonate/:id` which will log you in as that user for easier debugging.

The route is not available in `production` Rails environment.