### PR TITLE
Change event sorting to reverse chronological

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,7 +15,7 @@ class PagesController < ApplicationController
   end
 
   def meetups
-    @meetups = all_meetups.sort_by { |e| e['Event Start Date/Time'] }
+    @meetups = all_meetups.sort_by { |e| e['Event Start Date/Time'] }.reverse
   end
 
   def webinars


### PR DESCRIPTION
This PR makes events sort in reverse chronological order. 

In pry: 
<img width="887" alt="image" src="https://user-images.githubusercontent.com/7976757/65460647-66692f80-de20-11e9-9e2f-2186345a0946.png">

On the page: 
<img width="1172" alt="image" src="https://user-images.githubusercontent.com/7976757/65460660-6b2de380-de20-11e9-890e-6e2faac58871.png">

This stack overflow post said that .reverse was the best and most efficient way to achieve this: https://stackoverflow.com/questions/2642182/sorting-an-array-in-descending-order-in-ruby
