### PR TITLE
Add appropriate link to 'Introduction to Open Source'

### DIFF
--- a/app/views/pages/details_resources/_beginners_resources.html.erb
+++ b/app/views/pages/details_resources/_beginners_resources.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <p>If you’re new to open source (everyone was once!),
-    take a look at our Introduction to Open Source series.</p>
+    take a look at our </p> <a href="https://www.digitalocean.com/community/tutorial_series/an-introduction-to-open-source">Introduction to Open Source series.</a>
   <p>Before you make your first contribution, you should
     familiarize yourself with
   <a href="https://www.digitalocean.com/community/tutorials/how-to-create-a-pull-request-on-github">


### PR DESCRIPTION
Add the appropriate link to 'Introduction to Open Source' in the `Beginners` section of `Details` page.