### PR TITLE
Mount sidekiq unless no sidekiq password is set

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,11 +21,15 @@ Rails.application.routes.draw do
   get '/thanks' => 'pages#thanks'
   get '/boom', to: 'boom#show'
 
-  Sidekiq::Web.use Rack::Auth::Basic do |username, password|
-    ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
-      ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))
-  end if Rails.env.production?
-  mount Sidekiq::Web, at: "/sidekiq" unless ENV["SIDEKIQ_PASSWORD"].blank?
+  if Rails.env.production?
+    Sidekiq::Web.use Rack::Auth::Basic do |username, password|
+      ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
+        ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))
+    end 
+    mount Sidekiq::Web, at: "/sidekiq" unless ENV["SIDEKIQ_PASSWORD"].blank?
+  else
+    mount Sidekiq::Web, at: "/sidekiq"
+  end
 
   unless Rails.env.production?
     get '/impersonate/:id', to: 'sessions#impersonate', as: :impersonate


### PR DESCRIPTION
Simplification of Sidekiq mounting logic. Sidekiq will now mount in any environment, and only expects a password in production