### PR TITLE
Fix for event boxes 

### DIFF
--- a/app/assets/stylesheets/homepage.scss
+++ b/app/assets/stylesheets/homepage.scss
@@ -128,27 +128,6 @@ main.home {
     }
   }
 
-  .eventUnion {
-    display: flex;
-    justify-content: space-between;
-    vertical-align: baseline;
-    margin-bottom: 60px;
-
-    .box {
-      display: flex;
-      flex-direction: column;
-      justify-content: space-between;
-    }
-
-    @media screen and (max-width: $break-small) {
-      flex-direction: column;
-    }
-    .box span {
-      width: 100%;
-      float: left;
-    }
-  }
-
   .box.projects {
     position: relative;
     display: flex;
@@ -159,6 +138,7 @@ main.home {
     margin-right: 0;
     margin-top: 0;
     width: 100%;
+    background-color: transparent;
 
     .title-wrap {
       display: flex;
@@ -187,6 +167,28 @@ main.home {
       p.details {
         margin: 0;
       }
+    }
+  }
+
+  .eventUnion {
+    display: flex;
+    justify-content: space-between;
+    vertical-align: baseline;
+    margin-bottom: 60px;
+
+    .box {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      min-height: 100%;
+    }
+
+    @media screen and (max-width: $break-small) {
+      flex-direction: column;
+    }
+    .box span {
+      width: 100%;
+      float: left;
     }
   }
 

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -125,8 +125,8 @@
     <!-- FEATURED EVENTS GENERATED HERE -->
     <section class="eventUnion">
       <% @meetups.map do |m| %>
-      <a href="<%= m["Event URL"] %>">
-        <div class="box grow-shadow">
+      <a class="box grow-shadow" href="<%= m["Event URL"] %>">
+ 
           <span class="eventMonth">
             <% formatted_date= DateTime.parse(m["Event Start Date/Time"]).to_formatted_s(:long).split(" ") %>
             <%= formatted_date[0] %>
@@ -142,7 +142,7 @@
             <%= m["Event City"] %>, <%= m["Event Country"] %>
           </span>
           </div>
-        </div>
+  
       </a>
       <% end %>
     </section>


### PR DESCRIPTION
This PR fixes the home page event boxes background color and positioning, mobile styles
<img width="1238" alt="Screen Shot 2019-09-24 at 9 06 50 AM" src="https://user-images.githubusercontent.com/430064/65529262-abd23f00-deaa-11e9-999e-abff4593f317.png">
