### PR TITLE
Adjust closing tag for form modal in Event kits page

### DIFF
--- a/app/assets/javascripts/event_kit.js
+++ b/app/assets/javascripts/event_kit.js
@@ -1,5 +1,8 @@
-function formModal(form) {
+$(document).on('turbolinks:load', function() {
   if (window.location.href.includes('form')) {
-    $(form).addClass('is-active')
+    $('.modal').addClass('is-active')
   }
-}
+  $('#close-modal').click(function() {
+    $('.modal').removeClass('is-active')
+  });
+});

--- a/app/views/pages/event_kit.html.erb
+++ b/app/views/pages/event_kit.html.erb
@@ -3,7 +3,7 @@
   <div class="modal-content">
     <iframe class="modal-card " src="https://airtable.com/embed/shrD5rVJ7kfZec5hD?backgroundColor=blue" frameborder="0" onmousewheel="" width="100%" height="100%" style="background: transparent; border: 1px solid #ccc;"></iframe>
   </div>
-  <button class="modal-close">x</button>
+  <button id='close-modal' class="modal-close">'x'</button>
 </div>
 
 <div class="section is-fluid event-kit-page">
@@ -272,8 +272,4 @@
       <a href="mailto:hacktoberfestevents@digitalocean.com">hacktoberfestevents@digitalocean.com</a>.
     </p>
   </div>
-  <script type="text/javascript">
-    var form = document.getElementsByClassName('modal')
-    formModal(form)
-  </script>
 </div>


### PR DESCRIPTION
Updated JS to ensure modal can be closed.
Modal Reset on refresh.