### PR TITLE
Block register pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,14 +24,21 @@ class ApplicationController < ActionController::Base
     redirect_to login_path
   end
 
-  def require_user_registration!
-    return if logged_in? && @current_user.terms_acceptance
+  def require_user_registered!
+    return if logged_in? && !@current_user.new?
 
-    session[:destination] = request.path
-    if logged_in?
-      redirect_to register_form_path
-    else
-      redirect_to start_path
-    end
+    redirect_to start_path
+  end
+
+  def disallow_registered_user!
+    return unless logged_in? && !@current_user.new?
+
+    redirect_to profile_path
+  end
+
+  def disallow_logged_in_user!
+    return unless logged_in?
+
+    redirect_to register_form_path
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class PagesController < ApplicationController
+  before_action :disallow_registered_user!, only: :start
+  before_action :disallow_logged_in_user!, only: :start
+
   def index
     @events = all_events.select(&:featured?).first(4)
     @projects = ProjectService.sample(9)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,11 +6,7 @@ class SessionsController < ApplicationController
     session[:current_user_id] = @user.id
     store_user_info
     store_segment_user
-    if !@user.terms_acceptance
-      redirect_to register_form_path
-    else
-      redirect_to session[:destination] || '/'
-    end
+    redirect_to session[:destination] || '/'
   end
 
   def store_segment_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,8 @@
 
 class UsersController < ApplicationController
   before_action :require_user_logged_in!
-  before_action :require_user_registration!, only: :show
+  before_action :require_user_registered!, only: :show
+  before_action :disallow_registered_user!, only: :edit
 
   # render current user profile
   def show


### PR DESCRIPTION
Makes `/start` and `/register` inaccessible for users who are `logged_in?` and who have already completed the registration steps.