### PR TITLE
Use `Start Date` field for date in event presenter

### DIFF
--- a/app/presenters/airtable_event_presenter.rb
+++ b/app/presenters/airtable_event_presenter.rb
@@ -17,9 +17,7 @@ class AirtableEventPresenter
   end
 
   def date
-    date_time_arr = @event['Event Start Date/Time (Real)'].split(' ')
-    date = date_time_arr.first
-    Date.strptime(date, '%m/%d/%Y')
+    Date.strptime(@event['Event Start Date'], '%Y-%m-%d')
   rescue StandardError
     nil
   end

--- a/spec/presenters/airtable_event_presenter_spec.rb
+++ b/spec/presenters/airtable_event_presenter_spec.rb
@@ -39,10 +39,7 @@ describe AirtableEventPresenter do
 
         expect(event_presenter.name).to eq event['Event Name']
         expect(event_presenter.date)
-          .to eq Date.strptime(
-            event['Event Start Date/Time (Real)'].split(' ').first,
-            '%m/%d/%Y'
-          )
+          .to eq Date.strptime(event['Event Start Date'],'%Y-%m-%d')
         expect(event_presenter.state).to eq event['Event State']
         expect(event_presenter.country).to eq event['Event Country']
         expect(event_presenter.location).to include(


### PR DESCRIPTION
Solves issue #206 

Now using `Start Date` field in event presenter. The data comes to us as 2019-10-19 and we parse that date to be used for filtering and sorting.

Display remains the same with `Mon, DD`

<img width="1262" alt="image" src="https://user-images.githubusercontent.com/7976757/65719294-86dcf800-e073-11e9-8e1f-44d7ba90d129.png">
