### PR TITLE
Include PRs of all states

### DIFF
--- a/app/models/github_pull_request.rb
+++ b/app/models/github_pull_request.rb
@@ -21,10 +21,6 @@ class GithubPullRequest
     @graphql_hash.url
   end
 
-  def state
-    @graphql_hash.state
-  end
-
   def created_at
     @graphql_hash.createdAt
   end

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -7,10 +7,10 @@ class PullRequest
     @github_pull_request = github_pull_request
   end
 
-  delegate :id, :title, :body, :url, :state, :created_at,
+  delegate :id, :title, :body, :url, :created_at,
            :label_names, to: :github_pull_request
 
-  def status
+  def state
     if label_names.include?('invalid')
       'invalid'
     else
@@ -18,21 +18,13 @@ class PullRequest
     end
   end
 
-  def state
-    @github_pull_request.state
-  end
-
   def eligible?
-    status == 'eligible'
+    state == 'eligible'
   end
 
   def mature?
     pr_date = DateTime.parse(@github_pull_request.created_at)
 
     pr_date < (DateTime.now - Hacktoberfest.pull_request_maturation_days)
-  end
-
-  def merged?
-    state == 'MERGED'
   end
 end

--- a/app/views/users/show/_timeline.html.erb
+++ b/app/views/users/show/_timeline.html.erb
@@ -21,7 +21,7 @@
         </div></td>
         <td><div>
           <p> <%=  DateTime.parse(pr.created_at).to_formatted_s(:long) %><br/> </p>
-          <h3 class="title is-3">You <%= pr.merged? ? "merged" : "opened" %> <a href="<%= pr.url %>"><%= pr.title %></a> in <%= pr.url.split('/')[3] %><br/></h3>
+          <h3 class="title is-3">You opened <a href="<%= pr.url %>"><%= pr.title %></a> in <%= pr.url.split('/')[3] %><br/></h3>
         </div></td>
           <% if pr.eligible? && @presenter.user.waiting? %>
           <td><div>


### PR DESCRIPTION
Modify GitHub pull request query to return 1) merged **and** open prs, and `state` with each pr 

Adds `#status` and `#merged?` to pull_request 

Adds conditional to view to show open or merged status of each PR: 

<img width="1163" alt="image" src="https://user-images.githubusercontent.com/7976757/65728163-1b515580-e088-11e9-9386-e2f1babdd9f4.png">

tests passing: 

<img width="690" alt="image" src="https://user-images.githubusercontent.com/7976757/65728187-302de900-e088-11e9-99e9-ec173733eb23.png">

