### PR TITLE
Move dotenv-rails gem to be used in all environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "bulma-rails", "~> 0.7.5"
 gem 'coffee-rails', '~> 4.2'
 
 gem 'dalli', '~> 2.7'
-gem 'dotenv-rails'
+gem 'dotenv-rails', require: 'dotenv/rails-now'
 
 gem 'faraday'
 gem 'faraday_middleware'


### PR DESCRIPTION
This was an attempt to fix #214 which did not work