### PR TITLE
Add spam information to Details

### DIFF
--- a/app/views/pages/details.html.erb
+++ b/app/views/pages/details.html.erb
@@ -30,12 +30,14 @@
       </div>
 
     </div>
+
     <div class="container details">
       <h1 id="event-details" class="title is-1"><a href="#event-details">Event details</a></h1>
       <p><span class="highlight">●</span> Hacktoberfest is open to everyone in our global community!</p>
       <p><span class="highlight">●</span> Pull requests can be made in any GitHub-hosted repositories/projects.</p>
       <p><span class="highlight">●</span> You can sign up anytime between October 1 and October 31.</p>
     </div>
+
     <div class="container details">
       <h1 id="participation-rules" class="title is-1"><a href="#participation-rules">Participation rules</a></h1>
       <p>To qualify for the official limited edition Hacktoberfest shirt,
@@ -48,6 +50,7 @@
         complete the challenge will earn a T-shirt. (Last year 46,088
         earned a shirt!)</p>
     </div>
+
     <div class="container details">
       <h1 id="quality-standards" class="title is-1"><a href="#quality-standards">Quality standards</a></h1>
       <p>In line with Hacktoberfest value #2 (Quantity is fun,
@@ -62,6 +65,7 @@
       <p><span class="highlight">●</span> Last but not least, one PR to fix a typo is fine. 5 PRs to remove a stray
         whitespace... not. </p>
     </div>
+
     <div class="container details">
       <h1 id="values" class="title is-1"><a href="#values">Values</a></h1>
       <p>Inspired by you – the community – through your actions and stories.</p>
@@ -77,6 +81,37 @@
         open source community, we stand on the shoulders of those who came before
         us. Your participation has a lasting effect on people and technology long
         after October comes to an end. This is a voyage, not a race.</p>
+    </div>
+
+    <div class="container details">
+      <h1 id="spam" class="title is-1"><a href="#spam">Let’s work together to reduce spam</a></h1>
+      <p>
+        <span class="highlight">●</span> <b>Spammy PRs can be labeled as “invalid.” </b>
+        Maintainers are faced with the majority of spam that occurs during Hacktoberfest, and we dislike spam just as
+        much as you. If you’re a maintainer, please label any spammy PRs submitted to the repositories you maintain as
+        <b>invalid</b>, and close them. PRs with this label won't count toward Hacktoberfest.
+      </p>
+      <p>
+        <span class="highlight">●</span> <b>There’s a seven-day review window for PRs. </b>
+        This year, we've implemented a new seven-day grace period that all PRs for Hacktoberfest must go through before
+        they count toward completing the challenge. Once a participant has submitted four eligible PRs (ready-to-review,
+        not drafts), the review window begins. This period gives maintainers time to identify and label spammy PRs as
+        <b>invalid</b>. If the PRs are not marked <b>invalid</b> within that window, they will allow the user to
+        complete the Hacktoberfest challenge. If any of the PRs are labeled as <b>invalid</b>, however, the user will
+        return to the pending state until they have four eligible PRs, at which point the review period will then start
+        again.
+      </p>
+      <p>
+        <span class="highlight">●</span> <b>Bad repositories will be excluded. </b>
+        In the past, we've seen many repositories that encourage participants to make simple PRs – such as adding their
+        name to a file – to quickly gain a PR toward winning Hacktoberfest. While this may be a learning tool for new
+        contributors, it goes against one of our core values for Hacktoberfest. The quality of pull requests is
+        paramount; quantity comes second. These repositories do not encourage quality contributions and provide an
+        unfair advantage in completing the Hacktoberfest challenge. This year, we've implemented a system to block these
+        repositories, and any pull requests submitted to such repositories will not be counted. If you’d like to report
+        a repository, please email us at
+        <a href="mailto:hacktoberfest@digitalocean.com">Hacktoberfest@DigitalOcean.com</a>.
+      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Add spam information copy from https://docs.google.com/document/d/1QHZm5E84Xey_f1QCV3BPj3InT7IPZiAeYFQp5yS8MWU/edit to the Details page.

![image](https://user-images.githubusercontent.com/12371363/65891955-565fcb80-e39d-11e9-9907-f5e506886a20.png)

(Reformat of the source was split into its own commit, hopefully that should be more review-able)