### PR TITLE
Use `User.sufficient_eligible_prs?` in `ineligible` state machine event

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ApplicationRecord
 
     event :ineligible do
       transition waiting: :registered,
-       unless: -> (user) { user.sufficient_eligible_prs? }
+        unless: -> (user) { user.sufficient_eligible_prs? }
     end
 
     state all - [:new] do


### PR DESCRIPTION
Instead of depending on the magic number `4`