### PR TITLE
Remove ref to brand guidelines in event kit

### DIFF
--- a/app/views/pages/event_kit.html.erb
+++ b/app/views/pages/event_kit.html.erb
@@ -139,9 +139,7 @@
     <div class="columns is-multiline box">
       <div class="column">
         <h3 class="title is-3">Promote your event</h3>
-        <p class="box-text" >Logos, banners, posters, and more! We kindly ask that you
-          adopt Hacktoberfest Brand Guidelines as you share your
-          event/content.</p>
+        <p class="box-text" >Logos, banners, posters, and more!</p>
         <a href="https://assets.digitalocean.com/hacktoberfest/hacktoberfest_2019_brand_assets.zip" class="button down-load-assets">Download assets here</a>
       </div>
       <div class="secondary-box column">


### PR DESCRIPTION
Remove the reference to the brand guidelines in the event kit that don't exist.

![image](https://user-images.githubusercontent.com/12371363/65972827-55dd3880-e462-11e9-909f-d4e0d8e8ccf1.png)
