### PR TITLE
Don't include PRs in GitHub search link

### DIFF
--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -57,7 +57,7 @@
     <div class="grid" id="project-list">
       <%= render partial: 'languages/all_projects', locals: { projects: @projects } %>
     </div>
-    <a href="https://github.com/search?q=label%3Ahacktoberfest+state%3Aopen&type=Issues">
+    <a href="https://github.com/search?q=label%3Ahacktoberfest+state%3Aopen+is%3Aissue&type=Issues">
       <button class="button" type="button" name="button">Browse more on GitHub</button>
     </a>
     <a name="climate"></a>


### PR DESCRIPTION
https://github.com/search?q=label%3Ahacktoberfest+state%3Aopen+is%3Aissue&type=Issues vs https://github.com/search?q=label%3Ahacktoberfest+state%3Aopen&type=Issues

TIL, as a PR is a type of issue (with an attached patch), GitHub will show them in the Issues type search unless you specify is:issue.