### PR TITLE
Transition users job every 2 hours

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -36,7 +36,7 @@ Sidekiq.configure_server do |config|
   # See: https://github.com/mperham/sidekiq/wiki/Ent-Periodic-Jobs
   config.periodic do |mgr|
     # Every hour
-    mgr.register('0 * * * *', TransitionAllUsersJob, retry: 3, queue: :critical)
+    mgr.register('0 */2 * * *', TransitionAllUsersJob, retry: 3, queue: :critical)
     # Every day at 3AM
     mgr.register('0 3 * * *', UpdateAllIssuesJob, retry: 3, queue: :critical)
     # Every day at 5AM


### PR DESCRIPTION
Now that we have > 70k users, we need to reduce this