### PR TITLE
Filter sensitive data

### DIFF
--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -7,23 +7,21 @@ VCR.configure do |c|
   c.hook_into :webmock
   c.configure_rspec_metadata!
 
-  c.filter_sensitive_data('<TEST_USER_GITHUB_TOKEN>') do
-    user_github_token
-  end
+  vars_to_obscure = [
+    'TEST_USER_GITHUB_TOKEN',
+    'GITHUB_CLIENT_SECRET',
+    'GITHUB_CLIENT_ID',
+    'SEGMENT_WRITE_KEY',
+    'AIRTABLE_API_KEY',
+    'AIRTABLE_APP_ID'
+  ]
 
-  c.filter_sensitive_data('<TEST_GITHUB_CLIENT_ID') do
-    ENV.fetch('GITHUB_CLIENT_ID')
-  end
+  vars_to_obscure.map do |var|
+    obfuscation_text = var.dup
+    obfuscation_text.prepend('<TEST_').concat('>')
 
-  c.filter_sensitive_data('<TEST_SEGMENT_WRITE_KEY>') do
-    segment_write_key
-  end
-
-  c.filter_sensitive_data('<TEST_AIRTABLE_API_KEY>') do
-    ENV.fetch('AIRTABLE_API_KEY')
-  end
-
-  c.filter_sensitive_data('<TEST_AIRTABLE_APP_ID>') do
-    ENV.fetch('AIRTABLE_APP_ID')
+    c.filter_sensitive_data(obfuscation_text) do
+      ENV.fetch(var)
+    end
   end
 end


### PR DESCRIPTION
Filters 

    'TEST_USER_GITHUB_TOKEN',
    'GITHUB_CLIENT_SECRET',
    'GITHUB_CLIENT_ID',
    'SEGMENT_WRITE_KEY',
    'GITHUB_CLIENT_ID',
    'AIRTABLE_API_KEY',
    'AIRTABLE_APP_ID'

 from future VCR recordings. No changes directly to VCR files in this pr because we will roll credentials - however @johndbritton / @mkcode not sure how easy/possible it is to roll app ids

These are the only remaining env vars used in requests that make it to our VCR files