### PR TITLE
Randomize, filter, and sort frontpage events

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -46,8 +46,7 @@ class PagesController < ApplicationController
   def front_page_events
     all_events
       .select(&:current?)
-      .shuffle
-      .first(4)
+      .sample(4)
       .sort_by { |e| e.date }
   end
 end


### PR DESCRIPTION
Solves #289 

Filter out past events
then select 4 random events using .shuffle and then .first(4) 
Then sort chronologically (Soonest events first)

Working nicely:
![2019-10-03 15 41 33](https://user-images.githubusercontent.com/7976757/66158884-d0d65880-e5f4-11e9-8e40-2d19122ff782.gif)

All tests passing, same failure as usual to be fixed in a currently open pr

<img width="1093" alt="image" src="https://user-images.githubusercontent.com/7976757/66158923-eea3bd80-e5f4-11e9-856b-a9276d3eb51f.png">
