### PR TITLE
Fix typo on event kit

### DIFF
--- a/app/views/pages/event_kit.html.erb
+++ b/app/views/pages/event_kit.html.erb
@@ -144,7 +144,7 @@
           <li>LinkedIn groups</li>
           <li>Google groups</li>
           <li>Newsletters, websites, and social media accounts that share startup/tech events regularly</li>
-          <li>Local code schools an universities</li>
+          <li>Local code schools and universities</li>
         </ul>
       </li>
       <li><a href="#form">Add your meetup event here.</a></li>


### PR DESCRIPTION
'schools an universities' -> 'schools and universities' 
Spotted by a user who let us know in support ticket #4725