### PR TITLE
Save receipt after transition to completed

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,7 +86,7 @@ class User < ApplicationRecord
       UserStateTransitionSegmentService.call(user, transition)
     end
 
-    before_transition to: :completed do |user, _transition|
+    after_transition to: :completed do |user, _transition|
       user.receipt = user.scoring_pull_requests
     end
 


### PR DESCRIPTION
Changes calculating and saving the receipt to happen after transition to completed. 

Tests remain in their prior state 

<img width="1090" alt="image" src="https://user-images.githubusercontent.com/7976757/66323059-32e2d680-e8f1-11e9-95b9-7da486851a68.png">
 