### PR TITLE
Github auth token bug workaround

### DIFF
--- a/app/services/github_retryable_graphql_api_client.rb
+++ b/app/services/github_retryable_graphql_api_client.rb
@@ -31,7 +31,7 @@ class GithubRetryableGraphqlApiClient
   def change_access_token
     # @access_token = GithubTokenService.random
     # Select our known good auth tokens as backup
-    @access_token = User.where(id: BACKUP_TOKEN_USER_IDS )
+    @access_token = User.where(id: BACKUP_TOKEN_USER_IDS)
                         .pluck(:provider_token)
                         .sample
   end


### PR DESCRIPTION
Workaround for github bug where otherwise valid user auth tokens do not work for the graphql query