### PR TITLE
Add no:assignee search param

### DIFF
--- a/app/services/hacktoberfest_project_query_composer.rb
+++ b/app/services/hacktoberfest_project_query_composer.rb
@@ -69,6 +69,7 @@ module HacktoberfestProjectQueryComposer
     search_clauses = [
       'state:open',
       'label:hacktoberfest',
+      'no:assignee'
     ]
     search_clauses.push(query_string) if query_string.present?
     search_clauses.join(' ')


### PR DESCRIPTION
A user reported via Twitter that we were showing some issues that were already assigned. This adds the GitHub `no:assignee` param to the project importer thing so this doesn't happen again.

I hope this is the right change to make to fix this?