### PR TITLE
Sort language filter alphabetically

### DIFF
--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -47,7 +47,7 @@
         <div class="field">
           <div class="control">
             <div class="select">
-              <%= collection_select(:language, :id, Language.all, :id, :name, prompt: "Select language", html_options: { class: 'language-dropdown'}) %>
+              <%= collection_select(:language, :id, Language.all.sort_by(&:name), :id, :name, prompt: "Select language", html_options: {class: 'language-dropdown'}) %>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Adds `sort_by` to the Language collection used for the issue filter on the homepage so that they're sorted alphabetically by their name -- this was suggested by a user through a support ticket.

| Branch | Production |
|--|--|
| ![image](https://user-images.githubusercontent.com/12371363/66406888-44f17180-e9e4-11e9-9e51-149cdecec217.png) | ![image](https://user-images.githubusercontent.com/12371363/66406901-49b62580-e9e4-11e9-9fb9-e398f53f454a.png) |

