### PR TITLE
Filter airbrake notices by environment for js errors

### DIFF
--- a/app/views/shared/_airbrake.html.erb
+++ b/app/views/shared/_airbrake.html.erb
@@ -5,7 +5,7 @@
   });
 
   airbrake.addFilter(function(notice) {
-    notice.context.environment = "<%= Rails.env %>";
+    notice.context.environment = "<%= Rails.env %>-js";
     return notice;
   });
 </script>


### PR DESCRIPTION
This PR appends `-js` to the environment variable for all errors thrown by airbrake-js to make it simple and fast to sort errors by frontend vs backend

Simply type environment into the filter/search bar in airbrake, and then select either `production-js`, `development-js`, or any other env we have plus `-js`

Finally, this will make it so when viewing strictly, say `production` errors, those will not include frontend errors - only backend.

![image](https://user-images.githubusercontent.com/7976757/66509566-52b8fc80-eaa1-11e9-983e-d052d3295a09.png)
