### PR TITLE
Adjust logic for rendering eligible box

### DIFF
--- a/app/views/users/show/_timeline.html.erb
+++ b/app/views/users/show/_timeline.html.erb
@@ -92,7 +92,7 @@
             <td colspan="2">
               <div class="winning-msg-cont">
                 <h1 class="title is-2 pink-highlight"> You did it! 🎉 </h1>
-                <span class="title is-3">You've made four eligible PRs for the Hacktoberfest — which means you officially completed this year’s challenge!</span>
+                <span class="title is-3">You've made four eligible PRs for Hacktoberfest — which means you officially completed this year’s challenge!</span>
               </div>
             </td>
           </tr>


### PR DESCRIPTION
### Eligible box for users in a winning state

Icon for an eligible pull request would default to `pending` due to faulty logic. 

- Use existing logic from show_congratulations method in profile presenter
  - This will ensure the correct PR icon appears for winning or completed users

This will close #326 