### PR TITLE
Langauge filter: Run change on load

### DIFF
--- a/app/assets/javascripts/language_filter.js
+++ b/app/assets/javascripts/language_filter.js
@@ -32,6 +32,9 @@ window.setupLanguageFilter = function () {
     }
   }
 
+  // Deal with browsers remembering last state of select
+  change();
+
   // Detect the select change event
   $id.change(change);
 


### PR DESCRIPTION
This reintroduces the change function that was being called during the setup of the filter initially that was dropped in https://github.com/raise-dev/hacktoberfest/pull/244

This allows for browsers, like Firefox, that remember the last selected item in the dropdown when a user navigates back to the page to work as expected with the filter re-applying when they return to the page.