### PR TITLE
Time fixes

### DIFF
--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -30,8 +30,4 @@ module Hacktoberfest
   def ended?
     Time.zone.now > end_date
   end
-
-  def active?
-    Time.zone.today > start_date && Time.zone.today < end_date
-  end
 end

--- a/spec/presenters/profile_page_presenter_spec.rb
+++ b/spec/presenters/profile_page_presenter_spec.rb
@@ -17,7 +17,6 @@ describe ProfilePagePresenter do
   context 'Hacktoberfest is in pre launch' do
     before do
       allow(Hacktoberfest).to receive(:pre_launch?).and_return(true)
-      allow(Hacktoberfest).to receive(:active?).and_return(false)
       allow(Hacktoberfest).to receive(:ended?).and_return(false)
     end
 
@@ -42,7 +41,6 @@ describe ProfilePagePresenter do
     before do
       allow(Hacktoberfest).to receive(:ended?).and_return(true)
       allow(Hacktoberfest).to receive(:pre_launch?).and_return(false)
-      allow(Hacktoberfest).to receive(:active?).and_return(false)
       allow(shirt_winner).to receive(:won_hacktoberfest?).and_return(true)
     end
 
@@ -84,7 +82,6 @@ describe ProfilePagePresenter do
       allow(Hacktoberfest).to receive(:end_date).and_return(Time.zone.today - 7)
       allow(Hacktoberfest).to receive(:ended?).and_return(true)
       allow(Hacktoberfest).to receive(:pre_launch?).and_return(false)
-      allow(Hacktoberfest).to receive(:active?).and_return(false)
       allow(incomplete_user).to receive(:hacktoberfest_ended?).and_return(true)
       allow(incomplete_user).to receive(:won_hacktoberfest?).and_return(false)
     end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe UsersController, type: :request do
       allow_any_instance_of(SegmentService).to receive(:track)
 
       allow(Hacktoberfest).to receive(:ended?).and_return(false)
-      allow(Hacktoberfest).to receive(:active?).and_return(true)
 
       allow_any_instance_of(UserEmailService).to receive(:emails)
         .and_return(['test@mail.com'])


### PR DESCRIPTION
Makes our time methods accurate to the second so we do not end early.

Removes totally unused `Hacktoberfest.active?` method.

![image](https://user-images.githubusercontent.com/283496/67067297-c31be980-f143-11e9-99ce-e40f862be109.png)
