### PR TITLE
Use a random available coupon rather than the first

### DIFF
--- a/app/models/shirt_coupon.rb
+++ b/app/models/shirt_coupon.rb
@@ -7,6 +7,6 @@ class ShirtCoupon < ApplicationRecord
   validates_associated :user
 
   def self.first_available
-    find_by(user_id: nil)
+    where(user_id: nil).order('RANDOM()').sample
   end
 end

--- a/app/models/sticker_coupon.rb
+++ b/app/models/sticker_coupon.rb
@@ -7,6 +7,6 @@ class StickerCoupon < ApplicationRecord
   validates_associated :user
 
   def self.first_available
-    find_by(user_id: nil)
+    where(user_id: nil).order('RANDOM()').sample
   end
 end


### PR DESCRIPTION
This helps avoid contention in highly concurrent operations, even though we do have locking this improves performance.