### PR TITLE
Validate receipt is set on user before transition to completed

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,10 @@ class User < ApplicationRecord
       validates :sticker_coupon, absence: true
     end
 
+    state all - [:new, :registered, :waiting] do
+      validates :receipt, presence: true
+    end
+
     state :waiting do
       validates :sufficient_eligible_prs?, inclusion: {
         in: [true], message: 'user does not have sufficient eligible prs' }
@@ -57,7 +61,6 @@ class User < ApplicationRecord
     state :completed do
       validates :won_hacktoberfest?, inclusion: {
         in: [true], message: 'user has not met all winning conditions' }
-      validates :receipt, presence: true
 
       def win
         assign_coupon
@@ -88,7 +91,7 @@ class User < ApplicationRecord
       UserStateTransitionSegmentService.call(user, transition)
     end
 
-    before_transition to: :completed do |user, _transition|
+    before_transition to: [:completed, :incompleted] do |user, _transition|
       user.receipt = user.scoring_pull_requests
     end
 

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -30,7 +30,7 @@ FactoryBot.define do
     trait :completed do
       state { 'completed' }
 
-      # just setting receipt data here for validations, else the create fails
+      # setting receipt data here for validations, else the create fails
       receipt { {"test": "test" }.to_json }
 
       after :build do |user|
@@ -41,6 +41,7 @@ FactoryBot.define do
 
     trait :incompleted do
       state { 'incompleted' }
+      receipt { {"test": "test" }.to_json }
 
       after :build do |user|
         allow(user).to receive(:eligible_pull_requests_count).and_return(3)
@@ -50,11 +51,13 @@ FactoryBot.define do
 
     trait :won_shirt do
       state { 'won_shirt' }
+      receipt { {"test": "test" }.to_json }
       shirt_coupon
     end
 
     trait :won_sticker do
       state { 'won_sticker' }
+      receipt { {"test": "test" }.to_json }
       sticker_coupon
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -307,6 +307,17 @@ RSpec.describe User, type: :model do
 
     context 'hacktoberfest has ended', :vcr do
       context 'user has insufficient eligible prs' do
+        before do
+          prs = pull_request_data(
+            [PR_DATA[:mature_array][0],
+            PR_DATA[:mature_array][1]]
+          ).map do |pr|
+            PullRequest.new(pr)
+          end
+    
+          allow(user).to receive(:scoring_pull_requests).and_return(prs)
+        end
+
         let(:user) { FactoryBot.create(:user) }
 
         before do
@@ -324,6 +335,33 @@ RSpec.describe User, type: :model do
         it 'persists the incompleted state', :vcr do
           user.reload
           expect(user.state).to eq('incompleted')
+        end
+
+        it 'persists a receipt of the scoring prs', :vcr do
+          user.reload
+          expect(user.receipt)
+            .to eq(JSON.parse(user.scoring_pull_requests.to_json))
+        end
+      end
+
+      context 'user has insufficient eligible prs but no receipt' do
+        let(:user) { FactoryBot.create(:user, :waiting) }
+
+        before do
+          allow(user).to receive(:hacktoberfest_ended?).and_return(true)
+          allow(user).to receive(:sufficient_eligible_prs?).and_return(true)
+          allow(user).to receive(:receipt).and_return(nil)
+
+          user.incomplete
+        end
+
+        it 'does not transition the user to the incomplete state', :vcr do
+          expect(user.state).to eq('waiting')
+        end
+
+        it 'persists the waiting state', :vcr do
+          user.reload
+          expect(user.state).to eq('waiting')
         end
       end
 


### PR DESCRIPTION
Receipt was not getting saved on the user consistently upon transitioning to the completed state.

This pr moves the receipt set to a `before_transition` block for the `completed` state and adds a validation for the receipt's presence when a user is entering the completed state.

A user now cannot be completed without a receipt
