### PR TITLE
Fix authentication loops

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,8 +15,10 @@ class SessionsController < ApplicationController
   end
 
   def store_user_info
-    @user.update(provider_token: auth_hash.credentials.token,
-                 name: auth_hash.info.nickname)
+    @user.update_columns(
+      provider_token: auth_hash.credentials.token,
+      name: auth_hash.info.nickname
+    )
   end
 
   def destroy


### PR DESCRIPTION
Sometimes `User` records end up in an invalid state and the user's auth token has been revoked. In this case, it's impossible for the user to login, because we can't update the record to have a valid token using `#update` due to failing validations.

This writes updates to the user directly to the DB during `SessionsController` actions.