### PR TITLE
Ignore modified github email address

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,6 @@ class User < ApplicationRecord
     state all - [:new] do
       validates :terms_acceptance, acceptance: true
       validates :email, presence: true
-      validates :email, inclusion: { in: :github_emails }
     end
 
     state all - [:won_shirt] do
@@ -51,6 +50,10 @@ class User < ApplicationRecord
 
     state all - [:new, :registered, :waiting] do
       validates :receipt, presence: true
+    end
+
+    state :registered do
+      validates :email, inclusion: { in: :github_emails }
     end
 
     state :waiting do


### PR DESCRIPTION
This removes the validation requiring that a user's email address be listed as verified on their GitHub account on all states but `registered`.

In order to register the user must select a verified email address.

If the user then deletes that email address from GitHub, the user will still be valid.

cc/ @MattIPv4 We should discuss this behavior to make sure it behaves the way you want.