### PR TITLE
Attempt win logic when the user enters completed state

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,6 +99,10 @@ class User < ApplicationRecord
     end
 
     after_transition to: :waiting, do: :update_waiting_since
+
+    after_transition to: :completed do |user, _transition|
+      user.win
+    end
   end
   # rubocop:enable Metrics/BlockLength, Layout/MultilineHashBraceLayout
 


### PR DESCRIPTION
Some users reported seeing the out of prizes screen when there were still prizes available.

This is because transitioning from `completed` to `won_shirt` or `won_sticker` state is a two step process. This makes it so that the we automatically attempt the win logic inline when a user enters the `completed` state. This way users will only see that page if we are truly out of prizes.