### PR TITLE
Stop sending score data to segment

### DIFF
--- a/app/services/user_pull_request_segment_updater_service.rb
+++ b/app/services/user_pull_request_segment_updater_service.rb
@@ -4,7 +4,8 @@ module UserPullRequestSegmentUpdaterService
   module_function
 
   def call(user)
-    segment(user).identify(pull_requests_count: user.score)
+    # disable sending score events to segment temporarily
+    # segment(user).identify(pull_requests_count: user.score)
   end
 
   def segment(user)


### PR DESCRIPTION
To reduce the number of Segment API calls.