### PR TITLE
Revert fixed width from #391

### DIFF
--- a/app/assets/stylesheets/homepage.scss
+++ b/app/assets/stylesheets/homepage.scss
@@ -260,12 +260,6 @@ main.home {
     }
   }
 
-  .main-closing-section {
-    @media screen and (max-width: $break-large) {
-      max-width: 60vw;
-    }
-  }
-
   .is-spaced {
     padding-top: 20px;
   }


### PR DESCRIPTION
Reverts fixed width added in #391 that was breaking the canvasjs chart at certain browser sizes.

| Master | Branch |
|--|--|
| ![image](https://user-images.githubusercontent.com/12371363/68076302-d4533000-fdaa-11e9-927a-2bdb439bc64e.png) | ![image](https://user-images.githubusercontent.com/12371363/68076304-d9b07a80-fdaa-11e9-83f8-bfb19ba8d103.png) |