### PR TITLE
Handle GitHub errors

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -114,6 +114,8 @@ class User < ApplicationRecord
       user.receipt = user.scoring_pull_requests
     end
 
+    before_transition to: :inactive, do: :update_state_before_inactive
+
     after_transition to: :waiting, do: :update_waiting_since
 
     after_transition to: :completed do |user, _transition|
@@ -158,6 +160,10 @@ class User < ApplicationRecord
     update(waiting_since: Time.zone.parse(
       latest_pr.github_pull_request.created_at
     ))
+  end
+
+  def update_state_before_inactive
+    update_attribute(:state_before_inactive, state)
   end
 
   def waiting_for_week?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,7 +96,8 @@ class User < ApplicationRecord
 
     state :inactive do
       validates :last_error, inclusion: {
-        in: ['GithubPullRequestService::UserNotFoundOnGithubError'],
+        in: ['GithubPullRequestService::UserNotFoundOnGithubError',
+             'Octokit::AccountSuspended'],
         message: "user's last_error must be UserNotFoundOnGithubError" }
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -163,7 +163,9 @@ class User < ApplicationRecord
   end
 
   def update_state_before_inactive
+    # rubocop:disable Rails/SkipsModelValidations
     update_attribute(:state_before_inactive, state)
+    # rubocop:enable Rails/SkipsModelValidations
   end
 
   def waiting_for_week?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,10 @@ class User < ApplicationRecord
                  unless: ->(user) { user.sufficient_eligible_prs? }
     end
 
+    event :deactivate do
+      transition all => :inactive
+    end
+
     state all - [:new] do
       validates :terms_acceptance, acceptance: true
       validates :email, presence: true
@@ -88,6 +92,12 @@ class User < ApplicationRecord
         in: [true], message: 'hacktoberfest has not yet ended' }
       validates :sufficient_eligible_prs?, inclusion: {
         in: [false], message: 'user has too many sufficient eligible prs' }
+    end
+
+    state :inactive do
+      validates :last_error, inclusion: {
+        in: ['GithubPullRequestService::UserNotFoundOnGithubError'],
+        message: "user's last_error must be UserNotFoundOnGithubError" }
     end
 
     before_transition do |user, _transition|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -114,7 +114,9 @@ class User < ApplicationRecord
       user.receipt = user.scoring_pull_requests
     end
 
-    before_transition to: :inactive, do: :update_state_before_inactive
+    before_transition to: :inactive do |user, transition|
+      user.update_state_before_inactive(transition)
+    end
 
     after_transition to: :waiting, do: :update_waiting_since
 
@@ -162,9 +164,9 @@ class User < ApplicationRecord
     ))
   end
 
-  def update_state_before_inactive
+  def update_state_before_inactive(transition)
     # rubocop:disable Rails/SkipsModelValidations
-    update_attribute(:state_before_inactive, state)
+    update_attribute(:state_before_inactive, transition.from)
     # rubocop:enable Rails/SkipsModelValidations
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -100,6 +100,8 @@ class User < ApplicationRecord
              'Octokit::AccountSuspended'],
         message: "user's last_error must be
           UserNotFoundOnGithubError or AccountSuspended" }
+
+      validates :state_before_inactive, presence: true
     end
 
     before_transition do |user, _transition|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,7 +56,7 @@ class User < ApplicationRecord
       validates :sticker_coupon, absence: true
     end
 
-    state all - %i[new registered waiting] do
+    state all - %i[new registered waiting inactive] do
       validates :receipt, presence: true
     end
 
@@ -98,7 +98,8 @@ class User < ApplicationRecord
       validates :last_error, inclusion: {
         in: ['GithubPullRequestService::UserNotFoundOnGithubError',
              'Octokit::AccountSuspended'],
-        message: "user's last_error must be UserNotFoundOnGithubError" }
+        message: "user's last_error must be
+          UserNotFoundOnGithubError or AccountSuspended" }
     end
 
     before_transition do |user, _transition|

--- a/app/services/github_error_handler.rb
+++ b/app/services/github_error_handler.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module GithubErrorHandler
+  module_function
+
+  HANDLED_ERRORS = [
+    Octokit::AccountSuspended,
+    GithubPullRequestService::UserNotFoundOnGithubError
+  ].freeze
+
+  def with_error_handling
+    yield
+  rescue *HANDLED_ERRORS => e
+    process_github_error(e)
+  end
+
+  def process_github_error(error)
+    case error
+    when Octokit::AccountSuspended
+      process_user_missing_error(error)
+    when GithubPullRequestService::UserNotFoundOnGithubError
+      process_user_missing_error(error)
+    else
+      raise error
+    end
+  end
+
+  def process_user_missing_error(error)
+    return unless (user_stat = UserStat.where(user_id: error.get_user.id).first)
+
+    user_stat.destroy
+  end
+end

--- a/app/services/github_error_handler.rb
+++ b/app/services/github_error_handler.rb
@@ -32,5 +32,7 @@ module GithubErrorHandler
     return unless (user_stat = UserStat.where(user_id: user.id).first)
 
     user_stat.destroy
+
+    user.deactivate
   end
 end

--- a/app/services/github_error_handler.rb
+++ b/app/services/github_error_handler.rb
@@ -15,7 +15,9 @@ module GithubErrorHandler
   end
 
   def process_github_error(error, user)
+    # rubocop:disable Rails/SkipsModelValidations
     user.update_attribute(:last_error, error.class)
+    # rubocop:enable Rails/SkipsModelValidations
     case error.class.to_s
     when 'Octokit::AccountSuspended'
       process_user_missing_error(error, user)

--- a/app/services/github_error_handler.rb
+++ b/app/services/github_error_handler.rb
@@ -29,10 +29,10 @@ module GithubErrorHandler
   end
 
   def process_user_missing_error(_error, user)
+    user.deactivate
+
     return unless (user_stat = UserStat.where(user_id: user.id).first)
 
     user_stat.destroy
-
-    user.deactivate
   end
 end

--- a/app/services/github_error_handler.rb
+++ b/app/services/github_error_handler.rb
@@ -18,10 +18,10 @@ module GithubErrorHandler
     # rubocop:disable Rails/SkipsModelValidations
     user.update_attribute(:last_error, error.class)
     # rubocop:enable Rails/SkipsModelValidations
-    case error.class.to_s
-    when 'Octokit::AccountSuspended'
+    case error
+    when Octokit::AccountSuspended
       process_user_missing_error(error, user)
-    when 'GithubPullRequestService::UserNotFoundOnGithubError'
+    when GithubPullRequestService::UserNotFoundOnGithubError
       process_user_missing_error(error, user)
     else
       raise error

--- a/app/services/github_error_handler.rb
+++ b/app/services/github_error_handler.rb
@@ -8,25 +8,26 @@ module GithubErrorHandler
     GithubPullRequestService::UserNotFoundOnGithubError
   ].freeze
 
-  def with_error_handling
+  def with_error_handling(user)
     yield
   rescue *HANDLED_ERRORS => e
-    process_github_error(e)
+    process_github_error(e, user)
   end
 
-  def process_github_error(error)
-    case error
-    when Octokit::AccountSuspended
-      process_user_missing_error(error)
-    when GithubPullRequestService::UserNotFoundOnGithubError
-      process_user_missing_error(error)
+  def process_github_error(error, user)
+    user.update_attribute(:last_error, error.class)
+    case error.class.to_s
+    when 'Octokit::AccountSuspended'
+      process_user_missing_error(error, user)
+    when 'GithubPullRequestService::UserNotFoundOnGithubError'
+      process_user_missing_error(error, user)
     else
       raise error
     end
   end
 
-  def process_user_missing_error(error)
-    return unless (user_stat = UserStat.where(user_id: error.get_user.id).first)
+  def process_user_missing_error(_error, user)
+    return unless (user_stat = UserStat.where(user_id: user.id).first)
 
     user_stat.destroy
   end

--- a/app/services/github_pull_request_service.rb
+++ b/app/services/github_pull_request_service.rb
@@ -3,7 +3,14 @@
 # Fetches Pull Requests for a user from the GitHub API
 # Returns an array of GraphqlPullRequest instances
 class GithubPullRequestService
-  class UserNotFoundOnGithubError < StandardError; end
+  class UserNotFoundOnGithubError < StandardError
+    attr_reader :user
+
+    def initialize(user)
+      @user = user
+    end
+  end
+
   attr_reader :user
 
   PULL_REQUEST_QUERY = <<~GRAPHQL
@@ -48,7 +55,7 @@ class GithubPullRequestService
 
     if response['errors']
       if response['errors'][0]['type'] == 'NOT_FOUND'
-        raise UserNotFoundOnGithubError
+        raise UserNotFoundOnGithubError.new(user)
       end
     end
 

--- a/app/services/github_pull_request_service.rb
+++ b/app/services/github_pull_request_service.rb
@@ -3,13 +3,7 @@
 # Fetches Pull Requests for a user from the GitHub API
 # Returns an array of GraphqlPullRequest instances
 class GithubPullRequestService
-  class UserNotFoundOnGithubError < StandardError
-    attr_reader :user
-
-    def initialize(user)
-      @user = user
-    end
-  end
+  class UserNotFoundOnGithubError < StandardError; end
 
   attr_reader :user
 
@@ -55,7 +49,7 @@ class GithubPullRequestService
 
     if response['errors']
       if response['errors'][0]['type'] == 'NOT_FOUND'
-        raise UserNotFoundOnGithubError.new(user)
+        raise UserNotFoundOnGithubError
       end
     end
 

--- a/app/services/import_pr_metadata_service.rb
+++ b/app/services/import_pr_metadata_service.rb
@@ -6,17 +6,12 @@ module ImportPrMetadataService
   def call(user)
     pr_service = PullRequestService.new(user, randomize_token: true)
 
-    begin
+    GithubErrorHandler.with_error_handling do
       pr_data = pr_service.all
-    rescue GithubPullRequestService::UserNotFoundOnGithubError
-      user_stat = UserStat.where(user_id: user.id).first
 
-      user_stat.destroy
-      return
-    end
-
-    pr_data.map do |pr|
-      ImportOnePrMetadataJob.perform_async(pr.url)
+      pr_data.map do |pr|
+        ImportOnePrMetadataJob.perform_async(pr.url)
+      end
     end
   end
 end

--- a/app/services/import_pr_metadata_service.rb
+++ b/app/services/import_pr_metadata_service.rb
@@ -6,7 +6,7 @@ module ImportPrMetadataService
   def call(user)
     pr_service = PullRequestService.new(user, randomize_token: true)
 
-    GithubErrorHandler.with_error_handling do
+    GithubErrorHandler.with_error_handling(user) do
       pr_data = pr_service.all
 
       pr_data.map do |pr|

--- a/app/services/import_repos_metadata_service.rb
+++ b/app/services/import_repos_metadata_service.rb
@@ -6,7 +6,7 @@ module ImportReposMetadataService
   def call(user)
     pr_service = PullRequestService.new(user, randomize_token: true)
 
-    GithubErrorHandler.with_error_handling do
+    GithubErrorHandler.with_error_handling(user) do
       pr_data = pr_service.all
 
       pr_data.map do |pr|

--- a/app/services/import_repos_metadata_service.rb
+++ b/app/services/import_repos_metadata_service.rb
@@ -6,18 +6,13 @@ module ImportReposMetadataService
   def call(user)
     pr_service = PullRequestService.new(user, randomize_token: true)
 
-    begin
+    GithubErrorHandler.with_error_handling do
       pr_data = pr_service.all
-    rescue GithubPullRequestService::UserNotFoundOnGithubError
-      user_stat = UserStat.where(user_id: user.id).first
 
-      user_stat.destroy
-      return
-    end
-
-    pr_data.map do |pr|
-      repo_id = pr.github_pull_request.repo_id
-      ImportRepoMetadataJob.perform_async(repo_id)
+      pr_data.map do |pr|
+        repo_id = pr.github_pull_request.repo_id
+        ImportRepoMetadataJob.perform_async(repo_id)
+      end
     end
   end
 end

--- a/app/services/try_user_transition_service.rb
+++ b/app/services/try_user_transition_service.rb
@@ -2,13 +2,15 @@
 
 module TryUserTransitionService
   def self.call(user)
-    case user.state
-    when 'registered'
-      TryUserTransitionFromRegisteredService.call(user)
-    when 'waiting'
-      TryUserTransitionFromWaitingService.call(user)
-    when 'completed'
-      TryUserTransitionFromCompletedService.call(user)
+    GithubErrorHandler.with_error_handling(user) do
+      case user.state
+      when 'registered'
+        TryUserTransitionFromRegisteredService.call(user)
+      when 'waiting'
+        TryUserTransitionFromWaitingService.call(user)
+      when 'completed'
+        TryUserTransitionFromCompletedService.call(user)
+      end
     end
   end
 end

--- a/app/services/user_state_transition_segment_service.rb
+++ b/app/services/user_state_transition_segment_service.rb
@@ -15,6 +15,7 @@ module UserStateTransitionSegmentService
     when :incomplete then incomplete(user)
     when :ineligible then ineligible(user)
     when :won then won(user, transition)
+    when :deactivate then deactivate(user)
     end
   end
 
@@ -59,6 +60,11 @@ module UserStateTransitionSegmentService
         state: 'won_sticker'
       )
     end
+  end
+
+  def deactivate(user)
+    segment(user).track('user_inactive')
+    segment(user).identify(state: 'inactive')
   end
 
   def segment(user)

--- a/db/migrate/20191107151321_add_last_error_to_user.rb
+++ b/db/migrate/20191107151321_add_last_error_to_user.rb
@@ -1,0 +1,5 @@
+class AddLastErrorToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :last_error, :string
+  end
+end

--- a/db/migrate/20191107151321_add_last_error_to_user.rb
+++ b/db/migrate/20191107151321_add_last_error_to_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddLastErrorToUser < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :last_error, :string

--- a/db/migrate/20191111195936_add_state_before_inactive_to_user.rb
+++ b/db/migrate/20191111195936_add_state_before_inactive_to_user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddStateBeforeInactiveToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :state_before_inactive, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_28_180239) do
+ActiveRecord::Schema.define(version: 2019_11_07_151321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "daily_pr_counts", force: :cascade do |t|
+    t.date "date", null: false
+    t.integer "count", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["date"], name: "index_daily_pr_counts_on_date", unique: true
+  end
 
   create_table "issues", force: :cascade do |t|
     t.string "title", limit: 191, null: false
@@ -104,6 +112,7 @@ ActiveRecord::Schema.define(version: 2019_10_28_180239) do
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "deleted"
   end
 
   create_table "users", force: :cascade do |t|
@@ -119,6 +128,7 @@ ActiveRecord::Schema.define(version: 2019_10_28_180239) do
     t.string "state"
     t.datetime "waiting_since"
     t.jsonb "receipt"
+    t.string "last_error"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_07_151321) do
+ActiveRecord::Schema.define(version: 2019_11_11_195936) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -129,6 +129,7 @@ ActiveRecord::Schema.define(version: 2019_11_07_151321) do
     t.datetime "waiting_since"
     t.jsonb "receipt"
     t.string "last_error"
+    t.string "state_before_inactive"
   end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -564,15 +564,34 @@ RSpec.describe User, type: :model do
 
       context 'the user is in the any state' do
         let(:user) { FactoryBot.create(:user) }
+        context 'the state_before_inactive gets set successfully' do
+          before { user.deactivate }
 
-        before { user.deactivate }
+          it 'transitions the user to the inactive state' do
+            expect(user.state).to eq('inactive')
+          end
 
-        it 'transitions the user to the inactive state' do
-          expect(user.state).to eq('inactive')
+          it 'saves the previous state as state_before_inactive' do
+            expect(user.state_before_inactive).to eq('registered')
+          end
         end
+        context 'the state_before_inactive does not get set' do
+          before do
+            allow(user).to receive(:state_before_inactive).and_return(nil)
+          end
 
-        it 'saves the previous state as state_before_inactive' do
-          expect(user.state_before_inactive).to eq('registered')
+          it 'does not transition the user to the inactive state' do
+            user.deactivate
+
+            expect(user.state).to_not eq('inactive')
+          end
+
+          it 'applies the correct errors to the user object' do
+            user.deactivate
+
+            expect(user.errors.messages[:state_before_inactive].first)
+              .to eq("can't be blank")
+          end
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -551,11 +551,28 @@ RSpec.describe User, type: :model do
           expect(user.state).to eq('won_sticker')
         end
       end
+    end
 
-      context 'no coupons available' do
-        it 'does not transition the user' do
-          user.win
-          expect(user.state).to eq('completed')
+    describe '#deactivate' do
+      before do
+        allow(UserStateTransitionSegmentService)
+          .to receive(:deactivate).and_return(true)
+
+        allow_any_instance_of(User)
+          .to receive(:last_error).and_return('Octokit::AccountSuspended')
+      end
+
+      context 'the user is in the any state' do
+        let(:user) { FactoryBot.create(:user) }
+
+        before { user.deactivate }
+
+        it 'transitions the user to the inactive state' do
+          expect(user.state).to eq('inactive')
+        end
+
+        it 'saves the previous state as state_before_inactive' do
+          expect(user.state_before_inactive).to eq('registered')
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -556,7 +556,7 @@ RSpec.describe User, type: :model do
     describe '#deactivate' do
       before do
         allow(UserStateTransitionSegmentService)
-          .to receive(:deactivate).and_return(true)
+          .to receive(:call).and_return(true)
 
         allow_any_instance_of(User)
           .to receive(:last_error).and_return('Octokit::AccountSuspended')

--- a/spec/services/github_error_handler_spec.rb
+++ b/spec/services/github_error_handler_spec.rb
@@ -4,6 +4,13 @@ require 'rails_helper'
 
 RSpec.describe GithubErrorHandler do
   let(:user) { FactoryBot.create(:user) }
+
+  # stub API call that will happen due to User#deactivate
+  before do
+    allow(UserStateTransitionSegmentService)
+      .to receive(:call).and_return(true)
+  end
+
   describe '.process_github_error' do
     context 'The error is UserNotFoundOnGithubError' do
       let(:error) { GithubPullRequestService::UserNotFoundOnGithubError.new }

--- a/spec/services/github_error_handler_spec.rb
+++ b/spec/services/github_error_handler_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GithubErrorHandler do
+  let(:user) { FactoryBot.create(:user) }
+  describe '.process_github_error' do
+    context 'The error is UserNotFoundOnGithubError' do
+      let(:error) { GithubPullRequestService::UserNotFoundOnGithubError.new }
+
+      it 'calls process_user_missing_error' do
+        expect(GithubErrorHandler)
+          .to receive(:process_user_missing_error).with(error, user)
+
+        GithubErrorHandler.process_github_error(error, user)
+      end
+
+      it 'correctly updates the last_error column on the user' do
+        GithubErrorHandler.process_github_error(error, user)
+
+        expect(user.last_error).to eq(error.class.to_s)
+      end
+    end
+
+    context 'The error is Octokit::AccountSuspended' do
+      let(:error) { Octokit::AccountSuspended.new }
+
+      it 'calls process_user_missing_error' do
+        expect(GithubErrorHandler)
+          .to receive(:process_user_missing_error).with(error, user)
+
+        GithubErrorHandler.process_github_error(error, user)
+      end
+
+      it 'correctly updates the last_error column on the user' do
+        GithubErrorHandler.process_github_error(error, user)
+
+        expect(user.last_error).to eq(error.class.to_s)
+      end
+    end
+
+    context 'The error is an unhandled error' do
+      let(:error) { StandardError.new }
+
+      it 'raises the error' do
+        expect { GithubErrorHandler.process_github_error(error, user) }
+          .to raise_error(StandardError)
+      end
+    end
+  end
+
+  describe '.process_user_missing_error' do
+    let(:error) { GithubPullRequestService::UserNotFoundOnGithubError.new }
+    it 'destroys the UserStat' do
+      UserStat.create(user_id: user.id, data: user)
+
+      GithubErrorHandler.process_user_missing_error(error, user)
+
+      expect(UserStat.count).to eq(0)
+    end
+
+    it 'deactivates the user' do
+      # to pass user#deactivate validations
+      allow(user)
+        .to receive(:last_error).and_return('Octokit::AccountSuspended')
+
+      GithubErrorHandler.process_user_missing_error(error, user)
+
+      expect(user.state).to eq('inactive')
+    end
+  end
+end

--- a/spec/services/import_repos_metadata_service_spec.rb
+++ b/spec/services/import_repos_metadata_service_spec.rb
@@ -5,6 +5,13 @@ require 'rails_helper'
 RSpec.describe ImportReposMetadataService do
   describe '.call' do
     let(:user) { FactoryBot.create(:user) }
+
+    # stub API call that will happen due to User#deactivate
+    before do
+      allow(UserStateTransitionSegmentService)
+        .to receive(:call).and_return(true)
+    end
+
     context 'The user has no PRs' do
       before do
         allow_any_instance_of(PullRequestService)


### PR DESCRIPTION
__Moved to #431__

----

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Fixes #409 

This PR consolidates error handling logic for the case when a user's account is suspended(`Octokit::AccountSuspended`) and when a user's account is missing from Github (`GithubPullRequestService::UserNotFoundOnGithubError`). This sits in a new service object which gets passed a user and a block, `GithubErrorHandler`.

For both of these errors, we handle by deactivating the user, putting them in the `inactive` state (a new state on the state machine specifically for these users no longer accounted for in GitHub) **and** deleting their associated `UserStat`, if they have one. 

# Test process
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

- [x] Test that a user causing this error gets deactivated and out in the `inactive` state
- [x] Test that that user's `UserStat` is deleted, if they had one
- [x] Test that if an unhandled error is passed to the GithubErrorHandler, it raises the error


# Requirements to merge
<!--
Ensure your pull request meets all the requirements for merging. Place an `x` in each box to indicate that your pull request meets that requirement.
-->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
