### PR TITLE
Fix CI failure caused by seed data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,1 @@
 # frozen_string_literal: true
-
-User.create!
-User.create!
-User.create!

--- a/spec/jobs/transition_all_users_job_spec.rb
+++ b/spec/jobs/transition_all_users_job_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe TransitionAllUsersJob, type: :job do
   Sidekiq::Testing.inline!
 
   before do
-    User.destroy_all
     2.times { FactoryBot.create(:user) }
   end
 


### PR DESCRIPTION
# Fix inconsistent CI failure

Resolves #414 

Notes:
_The file spec/jobs/transition_all_users_job_spec.rb: https://github.com/raise-dev/hacktoberfest/blob/972d3ab380cbe8754a500a7dd62dc55617f36c88/spec/jobs/transition_all_users_job_spec.rb has an inconsistent failure on CI. We expect there to be only 2 users when running the test, which is the case when running the specs locally. On CI only, there are 5 users in the DB when running this spec._

