### PR TITLE
Fix bad conditional transition event check for 'gifted' segment calls

### DIFF
--- a/app/services/user_state_transition_segment_service.rb
+++ b/app/services/user_state_transition_segment_service.rb
@@ -64,7 +64,7 @@ module UserStateTransitionSegmentService
 
   # TODO: change this to gifted(user, transition) and check transition.to to
   # add case for 'gifted_shirt' 
-  def gift_sticker(user)
+  def gifted(user)
     segment(user).identify(state: 'gifted_sticker')
     segment(user).track('user_gifted_sticker')
   end

--- a/app/services/user_state_transition_segment_service.rb
+++ b/app/services/user_state_transition_segment_service.rb
@@ -62,7 +62,7 @@ module UserStateTransitionSegmentService
     end
   end
 
-  # TODO: change this to gift(user, transition) and check transition.to to
+  # TODO: change this to gifted(user, transition) and check transition.to to
   # add case for 'gifted_shirt' 
   def gift_sticker(user)
     segment(user).identify(state: 'gifted_sticker')

--- a/app/services/user_state_transition_segment_service.rb
+++ b/app/services/user_state_transition_segment_service.rb
@@ -63,7 +63,7 @@ module UserStateTransitionSegmentService
   end
 
   # TODO: change this to gifted(user, transition) and check transition.to to
-  # add case for 'gifted_shirt' 
+  # add case for 'gifted_shirt'
   def gifted(user)
     segment(user).identify(state: 'gifted_sticker')
     segment(user).track('user_gifted_sticker')

--- a/app/services/user_state_transition_segment_service.rb
+++ b/app/services/user_state_transition_segment_service.rb
@@ -15,7 +15,7 @@ module UserStateTransitionSegmentService
     when :incomplete then incomplete(user)
     when :ineligible then ineligible(user)
     when :won then won(user, transition)
-    when :gift_sticker then gift_sticker(user)
+    when :gifted then gift_sticker(user)
     end
   end
 
@@ -62,6 +62,8 @@ module UserStateTransitionSegmentService
     end
   end
 
+  # TODO: change this to gift(user, transition) and check transition.to to
+  # add case for 'gifted_shirt' 
   def gift_sticker(user)
     segment(user).identify(state: 'gifted_sticker')
     segment(user).track('user_gifted_sticker')

--- a/app/services/user_state_transition_segment_service.rb
+++ b/app/services/user_state_transition_segment_service.rb
@@ -15,7 +15,7 @@ module UserStateTransitionSegmentService
     when :incomplete then incomplete(user)
     when :ineligible then ineligible(user)
     when :won then won(user, transition)
-    when :gifted then gift_sticker(user)
+    when :gifted then gifted(user)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -522,7 +522,7 @@ RSpec.describe User, type: :model do
   describe '#gift' do
     before do
       allow(UserStateTransitionSegmentService)
-        .to receive(:gift_sticker).and_return(true)
+        .to receive(:gifted).and_return(true)
     end
 
     context 'the user is in the incompleted state' do

--- a/spec/services/gift_service_spec.rb
+++ b/spec/services/gift_service_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe GiftService do
 
       context 'there is 1 sticker coupon' do
         before do
+          allow(UserStateTransitionSegmentService).to receive(:call)
           FactoryBot.create(:sticker_coupon)
           GiftService.call
         end
@@ -44,6 +45,7 @@ RSpec.describe GiftService do
 
       context 'there are 2 sticker coupons' do
         before do
+          allow(UserStateTransitionSegmentService).to receive(:call)
           FactoryBot.create(:sticker_coupon)
           FactoryBot.create(:sticker_coupon)
           GiftService.call
@@ -64,6 +66,7 @@ RSpec.describe GiftService do
 
       context 'there are 3 sticker coupons' do
         before do
+          allow(UserStateTransitionSegmentService).to receive(:call)
           FactoryBot.create(:sticker_coupon)
           FactoryBot.create(:sticker_coupon)
           FactoryBot.create(:sticker_coupon)

--- a/spec/services/user_state_transition_segment_service_spec.rb
+++ b/spec/services/user_state_transition_segment_service_spec.rb
@@ -186,11 +186,11 @@ RSpec.describe UserStateTransitionSegmentService do
       end
     end
 
-    context 'the event is gift_sticker and the user is incompleted' do
+    context 'the event is gifted and the user is incompleted' do
       let(:user) { FactoryBot.create(:user, :incompleted) }
 
       before do
-        allow(transition).to receive(:event).and_return(:gift_sticker)
+        allow(transition).to receive(:event).and_return(:gifted)
       end
 
       it 'calls SegmentService#identify with proper arguments' do


### PR DESCRIPTION
# Description
#437 introduced a bad conditional check in the `UserStateTransitionSegmentService`.
As a result, no segment calls were made. 

# Test process
- [x] Modify tests accordingly, looking for `gifted` event
- [x] Stub Segment calls in appropriate tests 

# Requirements to merge
- [x] Replace `gift_sticker` with `gifted`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
