### PR TITLE
Add new state to profile for showing the gifted sticker

### DIFF
--- a/app/presenters/profile_page_presenter.rb
+++ b/app/presenters/profile_page_presenter.rb
@@ -15,6 +15,10 @@ class ProfilePagePresenter
     @user.won_shirt? || @user.won_sticker?
   end
 
+  def display_sticker_gift?
+    @user.gifted_sticker?
+  end
+
   def display_waiting_for_prize?
     @user.completed?
   end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -31,6 +31,9 @@
       <% if @presenter.display_coupon? %>
           <%= render partial: 'users/show/display_coupons', locals: { code: @presenter.code } %>
       <% end %>
+      <% if @presenter.display_sticker_gift? %>
+        <%= render partial: 'users/show/display_sticker_gift', locals: { code: @presenter.code } %>
+      <% end %>
       <% if @presenter.display_waiting_for_prize? %>
           <%= render partial: 'users/show/waiting_for_prize', locals: { code: @presenter.code } %>
       <% end %>

--- a/app/views/users/show/_display_sticker_gift.html.erb
+++ b/app/views/users/show/_display_sticker_gift.html.erb
@@ -1,0 +1,22 @@
+<div class=level>
+  <div class="congratulations-txt">
+    <h1 class="title is-1">Thank you for your contributions!</h1>
+    <h3 class="title is-3">This marks the end of Hacktoberfest 2019.</h3>
+    <p>
+      As a token of our appreciation, we'll be sending you a limited edition Hacktoberfest sticker pack in celebration
+      of your achievement!
+    </p>
+    <p>Remember, this code is only for you. Don't share it with anyone!</p>
+    <p>After completing the form, please be patient until you receive a shipping confirmation via your email.</p>
+    <div class="coupon-box">
+      <div class="code-textarea box">
+        <label for="winner-code" class="is-sr-only">Prize URL</label>
+        <input type="text" id="winner-code" value="https://stores.kotisdesign.com/hacktoberfest/<%= code %>" readonly/>
+      </div>
+      <button class="button code-button" id="copy-winner-code" onclick="copyCodeToClipboard()">Copy</button>
+    </div>
+  </div>
+  <div>
+    <%= image_tag 'parrot.png' %>
+  </div>
+</div>

--- a/app/views/users/show/_display_sticker_gift.html.erb
+++ b/app/views/users/show/_display_sticker_gift.html.erb
@@ -11,7 +11,7 @@
     <div class="coupon-box">
       <div class="code-textarea box">
         <label for="winner-code" class="is-sr-only">Prize URL</label>
-        <input type="text" id="winner-code" value="https://stores.kotisdesign.com/hacktoberfest/<%= code %>" readonly/>
+        <input type="text" id="winner-code" value="https://stores.kotisdesign.com/hacktoberfeststickers/<%= code %>" readonly/>
       </div>
       <button class="button code-button" id="copy-winner-code" onclick="copyCodeToClipboard()">Copy</button>
     </div>


### PR DESCRIPTION
# Description

We sent an email to a lot of people saying we were giving them free stickers.
They sent us lots of tweets and emails back saying they couldn't see their codes.
This fixes that.

# Test process

- [ ] Set my user to be in the gifted_sticker state, added a test coupon in the sticker_coupons tab le
- [ ] With that in place, verified the profile showed the coupon with the correct wording
- [ ] Tested the profile with my user also in the incompleted & completed states to ensure those were unaffected

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes