### PR TITLE
Add error handling for GitHub 503s 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   before_action :set_current_user
   rescue_from Faraday::ClientError, with: :api_error
   rescue_from Octokit::Unauthorized, with: :github_unauthorized_error
+  rescue_from Octokit::ServiceUnavailable, with: :api_error
 
   def current_user
     return unless logged_in?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,8 @@ class ApplicationController < ActionController::Base
   before_action :set_current_user
   rescue_from Faraday::ClientError, with: :api_error
   rescue_from Octokit::Unauthorized, with: :github_unauthorized_error
-  rescue_from Octokit::ServiceUnavailable, with: :api_error
+  rescue_from Octokit::ServerError, with: :api_error
+  rescue_from Octokit::AccountSuspended, with: :github_suspended_error
 
   def current_user
     return unless logged_in?
@@ -62,5 +63,9 @@ class ApplicationController < ActionController::Base
 
   def github_unauthorized_error
     render 'pages/github_unauthorized_error', status: :unauthorized
+  end
+
+  def github_suspended_error
+    render 'pages/github_suspended_error', status: :forbidden
   end
 end

--- a/app/views/pages/github_suspended_error.html.erb
+++ b/app/views/pages/github_suspended_error.html.erb
@@ -1,0 +1,32 @@
+<div class="section">
+  <div class="container">
+    <div class="details">
+
+      <h1 class="title is-1">Something went wrong when talking to GitHub...</h1>
+      <p>
+        It looks like your GitHub account has been suspended.
+      </p>
+
+      <br/>
+      <br/>
+      <div class="line-br is-hidden-touch">
+        <span class="line-br-1">-</span>
+        <span class="line-br-2">-</span>
+      </div>
+      <br/>
+
+      <h3 class="title is-3">
+        Here's what you should try doing to see if we can get this sorted:
+      </h3>
+
+      <p>
+        <span class="highlight">●</span> <a href="https://support.github.com/contact">Create a support ticket</a>.
+      </p>
+      <p>
+        <span class="highlight">●</span> If the problem persists, please let us know by emailing
+        <a href="mailto:hacktoberfest@digitalocean.com">hacktoberfest@digitalocean.com</a>.
+      </p>
+
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
# Description
This PR addresses the known limitations of the GitHub API, encountered last year through 503s in the sign up process. By adding error handling for `Octokit::ServiceUnavailable` exceptions, we can provide a better user experience.
