### PR TITLE
Update instructions on running specs with Docker in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,13 @@ Run `docker-compose up -d` to start your services.
 If you would like to run commands against your app service, you can do that with the following command (using rubocop as an example): 
 
 ```
-docker-compose run app --entrypoint "bundle exec rubocop app config db lib spec --safe-auto-correct"
+docker-compose exec app bundle exec rubocop app config db lib spec --safe-auto-correct
+```
+
+Or to run a particular spec:
+
+```
+docker-compose exec app bundle exec rspec <your-spec-file>
 ```
 
 ### Setup Oauth Token


### PR DESCRIPTION
# Description
Quick update to README for running specs with Compose.

It should be possible to run any spec with `docker-compose exec app` following the syntax in the README.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
