### PR TITLE
Add categories to users with dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,13 @@ HACKTOBERFEST_DATABASE_PASSWORD=sekret
 REDIS_HOST=redis
 REDIS_PORT=6379
 DALLI_SERVER=memcached
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
-START_DATE=
-END_DATE=
-AIRTABLE_API_KEY=
-AIRTABLE_APP_ID=
+GITHUB_CLIENT_ID=<fill-in-for-dev-setup>
+GITHUB_CLIENT_SECRET=<fill-in-for-dev-setup>
+START_DATE=<fill-in-for-dev-setup>
+END_DATE=<fill-in-for-dev-setup>
+AIRTABLE_API_KEY=<fill-in-for-dev-setup>
+AIRTABLE_APP_ID=<fill-in-for-dev-setup>
+SEGMENT_WRITE_KEY=<leave-blank>
 ```
 **Note**: Use the following values when setting up your Oauth token:
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,7 +24,9 @@ class UsersController < ApplicationController
 
   # action to render register form
   def registration
-    @categories = %w[participant organizer maintainer]
+    @categories = { 'Participant' => 'Participant',
+                    'Event Organizer' => 'organizer',
+                    'Maintainer' => 'maintainer' }
     set_user_emails
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,7 @@ class UsersController < ApplicationController
 
   # action to render register form
   def registration
+    @categories = %w[participant organizer maintainer]
     set_user_emails
   end
 
@@ -63,7 +64,8 @@ class UsersController < ApplicationController
       :terms_acceptance,
       :digitalocean_marketing_emails,
       :intel_marketing_emails,
-      :dev_marketing_emails
+      :dev_marketing_emails,
+      :category
     )
   end
 

--- a/app/services/user_state_transition_segment_service.rb
+++ b/app/services/user_state_transition_segment_service.rb
@@ -25,6 +25,7 @@ module UserStateTransitionSegmentService
       digitalocean_marketing_emails: user.digitalocean_marketing_emails,
       intel_marketing_emails: user.intel_marketing_emails,
       dev_marketing_emails: user.dev_marketing_emails,
+      category: user.category,
       state: 'register'
     )
     segment(user).track('register')

--- a/app/views/users/registration.html.erb
+++ b/app/views/users/registration.html.erb
@@ -38,6 +38,15 @@
       </div>
 
       <div class="field">
+        <label class="label">Role</label>
+        <div class="control">
+          <div class="select">
+            <%= f.select :category, @categories %>
+          </div>
+        </div>
+      </div>
+
+      <div class="field">
         <div class="control">
           <label class="checkbox">
             <%= f.check_box :digitalocean_marketing_emails %>

--- a/db/migrate/20200911174700_add_category_to_users.rb
+++ b/db/migrate/20200911174700_add_category_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCategoryToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :category, :string, default: 'participant'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_10_203742) do
+ActiveRecord::Schema.define(version: 2020_09_11_174700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -122,6 +122,7 @@ ActiveRecord::Schema.define(version: 2020_09_10_203742) do
     t.jsonb "receipt"
     t.boolean "intel_marketing_emails", default: false
     t.boolean "dev_marketing_emails", default: false
+    t.string "category", default: "participant"
   end
 
 end

--- a/spec/services/user_state_transition_segment_service_spec.rb
+++ b/spec/services/user_state_transition_segment_service_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe UserStateTransitionSegmentService do
           digitalocean_marketing_emails: user.digitalocean_marketing_emails,
           intel_marketing_emails: user.intel_marketing_emails,
           dev_marketing_emails: user.dev_marketing_emails,
+          category: user.category,
           state: 'register'
         )
         allow_any_instance_of(SegmentService).to receive(:track).with(
@@ -33,6 +34,7 @@ RSpec.describe UserStateTransitionSegmentService do
           digitalocean_marketing_emails: user.digitalocean_marketing_emails,
           intel_marketing_emails: user.intel_marketing_emails,
           dev_marketing_emails: user.dev_marketing_emails,
+          category: user.category,
           state: 'register'
         )
         expect_any_instance_of(SegmentService).to receive(:track).with(


### PR DESCRIPTION
# Description
Includes categories for users (organizer, maintainer, or participant), with dropdown for selection in registration. Default to participant.

This PR also adds some unrelated specifications to the README for Docker env vars.

# Test process
When registering, the dropdown with options should be available, with "participant" as the default. After registration, the correct category should be present in the database.

# Requirements to merge
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
