### PR TITLE
Send updated PR count to segment whenever a new PR is created

### DIFF
--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -80,8 +80,10 @@ class PullRequest < ApplicationRecord
     @github_pull_request = ghpr
   end
 
-  def self.from_github_pull_request(ghpr)
-    pr = find_or_create_by(gh_id: ghpr.id)
+  def self.from_github_pull_request(ghpr, create = true)
+    pr = create ? find_or_create_by(gh_id: ghpr.id) : find_by(gh_id: ghpr.id)
+    return unless pr
+
     pr.define_github_pull_request(ghpr)
     pr.check_state
     pr

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -111,10 +111,6 @@ class User < ApplicationRecord
       validates :sticker_coupon, presence: true
     end
 
-    before_transition do |user, _transition|
-      UserPullRequestSegmentUpdaterService.call(user)
-    end
-
     after_transition do |user, transition|
       UserStateTransitionSegmentService.call(user, transition)
     end

--- a/app/services/pull_request_service.rb
+++ b/app/services/pull_request_service.rb
@@ -13,9 +13,26 @@ class PullRequestService
     # Create this service when we lookup spammy repos:
     # in order to lookup all Repo Spammy states in SQL query
     # prs = PullRequestStateLookupService.new(filtered_github_pull_requests)
-    filtered_github_pull_requests(github_pull_requests).map do |ghpr|
+
+    # new_prs allows us to track if a new PR exists, and update segment
+    # This is hacky, I know, I'm sorry
+    new_prs = false
+
+    prs = filtered_github_pull_requests(github_pull_requests).map do |ghpr|
+      # Try finding the existing PR
+      found_pr = PullRequest.from_github_pull_request(ghpr, false)
+      next found_pr if found_pr
+
+      # If not, create the new PR and we will need to update segment
+      new_prs = true
       PullRequest.from_github_pull_request(ghpr)
     end
+
+    # If there were new PRs, update segment
+    UserPullRequestSegmentUpdaterService.call(@user) if new_prs
+
+    # Done!
+    prs
   end
 
   def waiting_prs

--- a/app/services/user_pull_request_segment_updater_service.rb
+++ b/app/services/user_pull_request_segment_updater_service.rb
@@ -4,8 +4,7 @@ module UserPullRequestSegmentUpdaterService
   module_function
 
   def call(user)
-    # disable sending score events to segment temporarily
-    # segment(user).identify(pull_requests_count: user.score)
+    segment(user).identify(pull_requests_count: user.score)
   end
 
   def segment(user)

--- a/app/services/user_state_transition_segment_service.rb
+++ b/app/services/user_state_transition_segment_service.rb
@@ -26,6 +26,7 @@ module UserStateTransitionSegmentService
       intel_marketing_emails: user.intel_marketing_emails,
       dev_marketing_emails: user.dev_marketing_emails,
       category: user.category,
+      pull_requests_count: user.score,
       state: 'register'
     )
     segment(user).track('register')

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -12,6 +12,10 @@ FactoryBot.define do
     trait :new do
       terms_acceptance { false }
       state { 'new' }
+
+      after :build do |user|
+        PullRequestFilterHelper.pr_stub_helper(user, [])
+      end
     end
 
     trait :no_email do

--- a/spec/presenters/profile_page_presenter_spec.rb
+++ b/spec/presenters/profile_page_presenter_spec.rb
@@ -16,7 +16,7 @@ describe ProfilePagePresenter do
 
   before do
     allow(UserPullRequestSegmentUpdaterService)
-        .to receive(:call).and_return(false)
+      .to receive(:call).and_return(false)
   end
 
   context 'Hacktoberfest is in pre launch' do

--- a/spec/presenters/profile_page_presenter_spec.rb
+++ b/spec/presenters/profile_page_presenter_spec.rb
@@ -14,6 +14,11 @@ describe ProfilePagePresenter do
   let(:won_sticker_presenter) { ProfilePagePresenter.new(sticker_winner) }
   let(:incompleted_user_presenter) { ProfilePagePresenter.new(incomplete_user) }
 
+  before do
+    allow(UserPullRequestSegmentUpdaterService)
+        .to receive(:call).and_return(false)
+  end
+
   context 'Hacktoberfest is in pre launch' do
     before { travel_to Time.zone.parse(ENV['START_DATE']) - 7.days }
 

--- a/spec/presenters/profile_page_presenter_spec.rb
+++ b/spec/presenters/profile_page_presenter_spec.rb
@@ -16,7 +16,7 @@ describe ProfilePagePresenter do
 
   before do
     allow(UserPullRequestSegmentUpdaterService)
-      .to receive(:call).and_return(false)
+      .to receive(:call).and_return(true)
   end
 
   context 'Hacktoberfest is in pre launch' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,12 +47,6 @@ def segment_write_key
   ENV.fetch('SEGMENT_WRITE_KEY') { SecureRandom.hex(20) }
 end
 
-def magic_instance_of(klass)
-  instance = instance_double(klass)
-  allow(klass).to receive(:new) { instance }
-  instance
-end
-
 unless ENV['TEST_USER_GITHUB_TOKEN']
   puts <<~ENDWARNING
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,6 +47,12 @@ def segment_write_key
   ENV.fetch('SEGMENT_WRITE_KEY') { SecureRandom.hex(20) }
 end
 
+def magic_instance_of(klass)
+  instance = instance_double(klass)
+  allow(klass).to receive(:new) { instance }
+  instance
+end
+
 unless ENV['TEST_USER_GITHUB_TOKEN']
   puts <<~ENDWARNING
 

--- a/spec/requests/api_controller_spec.rb
+++ b/spec/requests/api_controller_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe ApiController, type: :request do
+  before do
+    allow(UserPullRequestSegmentUpdaterService)
+        .to receive(:call).and_return(false)
+  end
+
   describe '#state' do
     context 'unauthenticated' do
       context 'non-existent user' do

--- a/spec/requests/api_controller_spec.rb
+++ b/spec/requests/api_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ApiController, type: :request do
   before do
     allow(UserPullRequestSegmentUpdaterService)
-      .to receive(:call).and_return(false)
+      .to receive(:call).and_return(true)
   end
 
   describe '#state' do

--- a/spec/requests/api_controller_spec.rb
+++ b/spec/requests/api_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ApiController, type: :request do
   before do
     allow(UserPullRequestSegmentUpdaterService)
-        .to receive(:call).and_return(false)
+      .to receive(:call).and_return(false)
   end
 
   describe '#state' do

--- a/spec/services/coupon_service_spec.rb
+++ b/spec/services/coupon_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe CouponService do
   before do
     allow(UserPullRequestSegmentUpdaterService)
-        .to receive(:call).and_return(false)
+      .to receive(:call).and_return(false)
   end
 
   describe '#assign_coupon' do

--- a/spec/services/coupon_service_spec.rb
+++ b/spec/services/coupon_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe CouponService do
   before do
     allow(UserPullRequestSegmentUpdaterService)
-      .to receive(:call).and_return(false)
+      .to receive(:call).and_return(true)
   end
 
   describe '#assign_coupon' do

--- a/spec/services/coupon_service_spec.rb
+++ b/spec/services/coupon_service_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe CouponService do
+  before do
+    allow(UserPullRequestSegmentUpdaterService)
+        .to receive(:call).and_return(false)
+  end
+
   describe '#assign_coupon' do
     context 'with a completed user' do
       let(:user) { FactoryBot.create(:user, :completed) }

--- a/spec/services/gift_service_spec.rb
+++ b/spec/services/gift_service_spec.rb
@@ -4,8 +4,10 @@ require 'rails_helper'
 
 RSpec.describe GiftService do
   before do
-    allow(UserPullRequestSegmentUpdaterService).to receive(:call).and_return(false)
-    allow(UserStateTransitionSegmentService).to receive(:call).and_return(false)
+    allow(UserPullRequestSegmentUpdaterService)
+      .to receive(:call).and_return(false)
+    allow(UserStateTransitionSegmentService)
+      .to receive(:call).and_return(false)
   end
 
   describe '.call' do

--- a/spec/services/gift_service_spec.rb
+++ b/spec/services/gift_service_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe GiftService do
+  before do
+    allow(UserPullRequestSegmentUpdaterService).to receive(:call).and_return(false)
+    allow(UserStateTransitionSegmentService).to receive(:call).and_return(false)
+  end
+
   describe '.call' do
     context 'Users in the incompleted state' do
       before { travel_to Time.zone.parse(ENV['END_DATE']) + 1.day }
@@ -33,7 +38,6 @@ RSpec.describe GiftService do
 
       context 'there is 1 sticker coupon' do
         before do
-          allow(UserStateTransitionSegmentService).to receive(:call)
           FactoryBot.create(:sticker_coupon)
           GiftService.call
         end
@@ -47,7 +51,6 @@ RSpec.describe GiftService do
 
       context 'there are 2 sticker coupons' do
         before do
-          allow(UserStateTransitionSegmentService).to receive(:call)
           FactoryBot.create(:sticker_coupon)
           FactoryBot.create(:sticker_coupon)
           GiftService.call
@@ -68,7 +71,6 @@ RSpec.describe GiftService do
 
       context 'there are 3 sticker coupons' do
         before do
-          allow(UserStateTransitionSegmentService).to receive(:call)
           FactoryBot.create(:sticker_coupon)
           FactoryBot.create(:sticker_coupon)
           FactoryBot.create(:sticker_coupon)

--- a/spec/services/gift_service_spec.rb
+++ b/spec/services/gift_service_spec.rb
@@ -5,9 +5,9 @@ require 'rails_helper'
 RSpec.describe GiftService do
   before do
     allow(UserPullRequestSegmentUpdaterService)
-      .to receive(:call).and_return(false)
+      .to receive(:call).and_return(true)
     allow(UserStateTransitionSegmentService)
-      .to receive(:call).and_return(false)
+      .to receive(:call).and_return(true)
   end
 
   describe '.call' do

--- a/spec/services/pull_request_service_spec.rb
+++ b/spec/services/pull_request_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PullRequestService do
 
   before do
     allow(UserPullRequestSegmentUpdaterService)
-      .to receive(:call).and_return(false)
+      .to receive(:call).and_return(true)
     allow(SpamRepositoryService)
       .to receive(:call).and_return(false)
   end

--- a/spec/services/pull_request_service_spec.rb
+++ b/spec/services/pull_request_service_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe PullRequestService do
   let(:pr_service) { PullRequestService.new(user) }
 
   before do
+    allow(UserPullRequestSegmentUpdaterService).to receive(:call).and_return(false)
     allow(SpamRepositoryService).to receive(:call).and_return(false)
   end
 

--- a/spec/services/pull_request_service_spec.rb
+++ b/spec/services/pull_request_service_spec.rb
@@ -7,8 +7,10 @@ RSpec.describe PullRequestService do
   let(:pr_service) { PullRequestService.new(user) }
 
   before do
-    allow(UserPullRequestSegmentUpdaterService).to receive(:call).and_return(false)
-    allow(SpamRepositoryService).to receive(:call).and_return(false)
+    allow(UserPullRequestSegmentUpdaterService)
+      .to receive(:call).and_return(false)
+    allow(SpamRepositoryService)
+      .to receive(:call).and_return(false)
   end
 
   describe '.new' do

--- a/spec/services/try_user_transition_service_spec.rb
+++ b/spec/services/try_user_transition_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'TryUserTransitionService' do
   before do
     allow(UserPullRequestSegmentUpdaterService)
-        .to receive(:call).and_return(false)
+      .to receive(:call).and_return(false)
   end
 
   describe '.call' do

--- a/spec/services/try_user_transition_service_spec.rb
+++ b/spec/services/try_user_transition_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'TryUserTransitionService' do
   before do
     allow(UserPullRequestSegmentUpdaterService)
-      .to receive(:call).and_return(false)
+      .to receive(:call).and_return(true)
   end
 
   describe '.call' do

--- a/spec/services/try_user_transition_service_spec.rb
+++ b/spec/services/try_user_transition_service_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe 'TryUserTransitionService' do
+  before do
+    allow(UserPullRequestSegmentUpdaterService)
+        .to receive(:call).and_return(false)
+  end
+
   describe '.call' do
     context 'The user is in the registered state' do
       let(:user) { FactoryBot.create(:user) }

--- a/spec/services/user_pull_request_segment_updater_service_spec.rb
+++ b/spec/services/user_pull_request_segment_updater_service_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserPullRequestSegmentUpdaterService do
+  describe '.call' do
+    context 'the user has an initial set of pull requests' do
+      let(:user) { FactoryBot.create(:user) }
+
+      before(:each) do
+        PullRequestFilterHelper.pr_stub_helper(
+          user,
+          PR_DATA[:mature_array][0...3]
+        )
+      end
+
+      context 'when user#score is touched and the PRs are stored in the DB' do
+        it 'gets called once' do
+          expect(UserPullRequestSegmentUpdaterService).to receive(:call)
+          allow_any_instance_of(SegmentService).to receive(:identify)
+          user.score
+        end
+
+        it 'calls SegmentService#identify with the correct number of PRs' do
+          expect_any_instance_of(SegmentService)
+            .to receive(:identify).with(pull_requests_count: 3)
+          user.score
+        end
+      end
+    end
+
+    context 'the user has no new pull requests' do
+      let(:user) { FactoryBot.create(:user) }
+
+      before(:each) do
+        # Add the initial three PRs and ignore that Segment update
+        PullRequestFilterHelper.pr_stub_helper(
+          user,
+          PR_DATA[:mature_array][0...3]
+        )
+        allow(UserPullRequestSegmentUpdaterService)
+          .to receive(:call).and_return(false)
+        user.score
+        allow(UserPullRequestSegmentUpdaterService)
+          .to receive(:call).and_call_original
+
+        # Add no further pull requests
+      end
+
+      context 'when user#score is touched and the PRs are stored in the DB' do
+        it 'does not get called' do
+          expect(UserPullRequestSegmentUpdaterService).not_to receive(:call)
+          user.score
+        end
+      end
+    end
+
+    context 'the user gains a new pull request' do
+      let(:user) { FactoryBot.create(:user) }
+
+      before(:each) do
+        # Add the initial three PRs and ignore that Segment update
+        PullRequestFilterHelper.pr_stub_helper(
+          user,
+          PR_DATA[:mature_array][0...3]
+        )
+        allow(UserPullRequestSegmentUpdaterService)
+          .to receive(:call).and_return(false)
+        user.score
+        allow(UserPullRequestSegmentUpdaterService)
+          .to receive(:call).and_call_original
+
+        # Stub the user with four PRs, keeping the previous three in the DB
+        PullRequestFilterHelper.pr_stub_helper(
+          user,
+          PR_DATA[:mature_array],
+          false
+        )
+      end
+
+      context 'when user#score is touched and the PRs are stored in the DB' do
+        it 'gets called once' do
+          expect(UserPullRequestSegmentUpdaterService).to receive(:call)
+          allow_any_instance_of(SegmentService).to receive(:identify)
+          user.score
+        end
+
+        it 'calls SegmentService#identify with the correct number of PRs' do
+          expect_any_instance_of(SegmentService)
+            .to receive(:identify).with(pull_requests_count: 4)
+          user.score
+        end
+      end
+    end
+  end
+end

--- a/spec/services/user_pull_request_segment_updater_service_spec.rb
+++ b/spec/services/user_pull_request_segment_updater_service_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe UserPullRequestSegmentUpdaterService do
           PR_DATA[:mature_array][0...3]
         )
         allow(UserPullRequestSegmentUpdaterService)
-          .to receive(:call).and_return(false)
+          .to receive(:call).and_return(true)
         user.score
         allow(UserPullRequestSegmentUpdaterService)
           .to receive(:call).and_call_original
@@ -65,7 +65,7 @@ RSpec.describe UserPullRequestSegmentUpdaterService do
           PR_DATA[:mature_array][0...3]
         )
         allow(UserPullRequestSegmentUpdaterService)
-          .to receive(:call).and_return(false)
+          .to receive(:call).and_return(true)
         user.score
         allow(UserPullRequestSegmentUpdaterService)
           .to receive(:call).and_call_original
@@ -99,20 +99,20 @@ RSpec.describe UserPullRequestSegmentUpdaterService do
       before(:each) do
         # Add the initial three PRs and ignore that Segment update
         PullRequestFilterHelper.pr_stub_helper(
-            user,
-            PR_DATA[:large_immature_array][0...3]
+          user,
+          PR_DATA[:large_immature_array][0...3]
         )
         allow(UserPullRequestSegmentUpdaterService)
-            .to receive(:call).and_return(false)
+          .to receive(:call).and_return(true)
         user.score
         allow(UserPullRequestSegmentUpdaterService)
-            .to receive(:call).and_call_original
+          .to receive(:call).and_call_original
 
         # Stub the user with all six PRs, keeping the previous three in the DB
         PullRequestFilterHelper.pr_stub_helper(
-            user,
-            PR_DATA[:large_immature_array],
-            false
+          user,
+          PR_DATA[:large_immature_array],
+          false
         )
       end
 
@@ -127,7 +127,7 @@ RSpec.describe UserPullRequestSegmentUpdaterService do
           # You might be confused why this is 4, and not 6...
           # We send User#score to Segment, which is capped at 4
           expect_any_instance_of(SegmentService)
-              .to receive(:identify).with(pull_requests_count: 4)
+            .to receive(:identify).with(pull_requests_count: 4)
           user.score
         end
       end

--- a/spec/services/user_pull_request_segment_updater_service_spec.rb
+++ b/spec/services/user_pull_request_segment_updater_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe UserPullRequestSegmentUpdaterService do
         )
       end
 
-      context 'when user#score is touched and the PRs are stored in the DB' do
+      context 'when User#score is touched and the PRs are stored in the DB' do
         it 'gets called once' do
           expect(UserPullRequestSegmentUpdaterService).to receive(:call)
           allow_any_instance_of(SegmentService).to receive(:identify)
@@ -47,7 +47,7 @@ RSpec.describe UserPullRequestSegmentUpdaterService do
         # Add no further pull requests
       end
 
-      context 'when user#score is touched and the PRs are stored in the DB' do
+      context 'when User#score is touched and the PRs are stored in the DB' do
         it 'does not get called' do
           expect(UserPullRequestSegmentUpdaterService).not_to receive(:call)
           user.score
@@ -78,7 +78,7 @@ RSpec.describe UserPullRequestSegmentUpdaterService do
         )
       end
 
-      context 'when user#score is touched and the PRs are stored in the DB' do
+      context 'when User#score is touched and the PRs are stored in the DB' do
         it 'gets called once' do
           expect(UserPullRequestSegmentUpdaterService).to receive(:call)
           allow_any_instance_of(SegmentService).to receive(:identify)
@@ -88,6 +88,46 @@ RSpec.describe UserPullRequestSegmentUpdaterService do
         it 'calls SegmentService#identify with the correct number of PRs' do
           expect_any_instance_of(SegmentService)
             .to receive(:identify).with(pull_requests_count: 4)
+          user.score
+        end
+      end
+    end
+
+    context 'the user gains multiple new pull requests' do
+      let(:user) { FactoryBot.create(:user) }
+
+      before(:each) do
+        # Add the initial three PRs and ignore that Segment update
+        PullRequestFilterHelper.pr_stub_helper(
+            user,
+            PR_DATA[:large_immature_array][0...3]
+        )
+        allow(UserPullRequestSegmentUpdaterService)
+            .to receive(:call).and_return(false)
+        user.score
+        allow(UserPullRequestSegmentUpdaterService)
+            .to receive(:call).and_call_original
+
+        # Stub the user with all six PRs, keeping the previous three in the DB
+        PullRequestFilterHelper.pr_stub_helper(
+            user,
+            PR_DATA[:large_immature_array],
+            false
+        )
+      end
+
+      context 'when User#score is touched and the PRs are stored in the DB' do
+        it 'gets called once' do
+          expect(UserPullRequestSegmentUpdaterService).to receive(:call)
+          allow_any_instance_of(SegmentService).to receive(:identify)
+          user.score
+        end
+
+        it 'calls SegmentService#identify with the correct number of PRs' do
+          # You might be confused why this is 4, and not 6...
+          # We send User#score to Segment, which is capped at 4
+          expect_any_instance_of(SegmentService)
+              .to receive(:identify).with(pull_requests_count: 4)
           user.score
         end
       end

--- a/spec/services/user_state_transition_segment_service_spec.rb
+++ b/spec/services/user_state_transition_segment_service_spec.rb
@@ -4,7 +4,11 @@ require 'rails_helper'
 
 RSpec.describe UserStateTransitionSegmentService do
   let(:transition) { double }
-  let(:magic_segment_service) { magic_instance_of(SegmentService) }
+
+  before do
+    allow(UserPullRequestSegmentUpdaterService)
+        .to receive(:call).and_return(true)
+  end
 
   describe '.call' do
     context 'the transition event is register and the user is new' do
@@ -15,7 +19,7 @@ RSpec.describe UserStateTransitionSegmentService do
       end
 
       it 'calls SegmentService#identify with proper arguments' do
-        expect(magic_segment_service).to receive(:identify).with(
+        expect_any_instance_of(SegmentService).to receive(:identify).with(
           email: user.email,
           digitalocean_marketing_emails: user.digitalocean_marketing_emails,
           intel_marketing_emails: user.intel_marketing_emails,
@@ -24,14 +28,14 @@ RSpec.describe UserStateTransitionSegmentService do
           state: 'register',
           pull_requests_count: 0
         )
-        allow(magic_segment_service).to receive(:track).with(
+        allow_any_instance_of(SegmentService).to receive(:track).with(
           'register'
         )
         UserStateTransitionSegmentService.call(user, transition)
       end
 
       it 'calls SegmentService#track with proper arguments' do
-        allow(magic_segment_service).to receive(:identify).with(
+        allow_any_instance_of(SegmentService).to receive(:identify).with(
           email: user.email,
           digitalocean_marketing_emails: user.digitalocean_marketing_emails,
           intel_marketing_emails: user.intel_marketing_emails,
@@ -40,7 +44,7 @@ RSpec.describe UserStateTransitionSegmentService do
           state: 'register',
           pull_requests_count: 0
         )
-        expect(magic_segment_service).to receive(:track).with(
+        expect_any_instance_of(SegmentService).to receive(:track).with(
           'register'
         )
         UserStateTransitionSegmentService.call(user, transition)
@@ -55,26 +59,20 @@ RSpec.describe UserStateTransitionSegmentService do
       end
 
       it 'calls SegmentService#identify with proper arguments' do
-        expect(magic_segment_service).to receive(:identify).with(
-          state: 'completed'
-        )
-        expect(magic_segment_service).to receive(:identify).with(
-          pull_requests_count: 4
-        )
-        allow(magic_segment_service).to receive(:track).with(
+        allow_any_instance_of(SegmentService).to receive(:track).with(
           'user_completed'
+        )
+        expect_any_instance_of(SegmentService).to receive(:identify).with(
+          state: 'completed'
         )
         UserStateTransitionSegmentService.call(user, transition)
       end
 
       it 'calls SegmentService#track with proper arguments' do
-        allow(magic_segment_service).to receive(:identify).with(
+        allow_any_instance_of(SegmentService).to receive(:identify).with(
           state: 'completed'
         )
-        allow(magic_segment_service).to receive(:identify).with(
-          pull_requests_count: 4
-        )
-        expect(magic_segment_service).to receive(:track).with(
+        expect_any_instance_of(SegmentService).to receive(:track).with(
           'user_completed'
         )
         UserStateTransitionSegmentService.call(user, transition)
@@ -90,26 +88,20 @@ RSpec.describe UserStateTransitionSegmentService do
       let(:user) { FactoryBot.create(:user, :incompleted) }
 
       it 'calls SegmentService#identify with proper arguments' do
-        expect(magic_segment_service).to receive(:identify).with(
-          state: 'completed'
-        )
-        expect(magic_segment_service).to receive(:identify).with(
-          pull_requests_count: 3
-        )
-        allow(magic_segment_service).to receive(:track).with(
+        allow_any_instance_of(SegmentService).to receive(:track).with(
           'user_completed'
+        )
+        expect_any_instance_of(SegmentService).to receive(:identify).with(
+          state: 'completed'
         )
         UserStateTransitionSegmentService.call(user, transition)
       end
 
       it 'calls SegmentService#track with proper arguments' do
-        allow(magic_segment_service).to receive(:identify).with(
+        allow_any_instance_of(SegmentService).to receive(:identify).with(
           state: 'completed'
         )
-        allow(magic_segment_service).to receive(:identify).with(
-          pull_requests_count: 3
-        )
-        expect(magic_segment_service).to receive(:track).with(
+        expect_any_instance_of(SegmentService).to receive(:track).with(
           'user_completed'
         )
         UserStateTransitionSegmentService.call(user, transition)
@@ -126,26 +118,20 @@ RSpec.describe UserStateTransitionSegmentService do
       end
 
       it 'calls SegmentService#identify with proper arguments' do
-        expect(magic_segment_service).to receive(:identify).with(
-          state: 'insufficient'
-        )
-        expect(magic_segment_service).to receive(:identify).with(
-          pull_requests_count: 4
-        )
-        allow(magic_segment_service).to receive(:track).with(
+        allow_any_instance_of(SegmentService).to receive(:track).with(
           'user_insufficient'
+        )
+        expect_any_instance_of(SegmentService).to receive(:identify).with(
+          state: 'insufficient'
         )
         UserStateTransitionSegmentService.call(user, transition)
       end
 
       it 'calls SegmentService#track with proper arguments' do
-        allow(magic_segment_service).to receive(:identify).with(
+        allow_any_instance_of(SegmentService).to receive(:identify).with(
           state: 'insufficient'
         )
-        allow(magic_segment_service).to receive(:identify).with(
-          pull_requests_count: 4
-        )
-        expect(magic_segment_service).to receive(:track).with(
+        expect_any_instance_of(SegmentService).to receive(:track).with(
           'user_insufficient'
         )
         UserStateTransitionSegmentService.call(user, transition)
@@ -167,26 +153,20 @@ RSpec.describe UserStateTransitionSegmentService do
         end
 
         it 'calls SegmentService#identify with proper arguments' do
-          expect(magic_segment_service).to receive(:identify).with(
+          expect_any_instance_of(SegmentService).to receive(:identify).with(
             state: 'won_shirt'
           )
-          expect(magic_segment_service).to receive(:identify).with(
-            pull_requests_count: 4
-          )
-          allow(magic_segment_service).to receive(:track).with(
+          expect_any_instance_of(SegmentService).to receive(:track).with(
             'user_won_shirt'
           )
           UserStateTransitionSegmentService.call(user, transition)
         end
 
         it 'calls SegmentService#track with proper arguments' do
-          allow(magic_segment_service).to receive(:identify).with(
+          expect_any_instance_of(SegmentService).to receive(:identify).with(
             state: 'won_shirt'
           )
-          allow(magic_segment_service).to receive(:identify).with(
-            pull_requests_count: 4
-          )
-          expect(magic_segment_service).to receive(:track).with(
+          expect_any_instance_of(SegmentService).to receive(:track).with(
             'user_won_shirt'
           )
           UserStateTransitionSegmentService.call(user, transition)
@@ -201,26 +181,20 @@ RSpec.describe UserStateTransitionSegmentService do
         end
 
         it 'calls SegmentService#identify with proper arguments' do
-          expect(magic_segment_service).to receive(:identify).with(
+          expect_any_instance_of(SegmentService).to receive(:identify).with(
             state: 'won_sticker'
           )
-          expect(magic_segment_service).to receive(:identify).with(
-            pull_requests_count: 4
-          )
-          allow(magic_segment_service).to receive(:track).with(
+          expect_any_instance_of(SegmentService).to receive(:track).with(
             'user_won_sticker'
           )
           UserStateTransitionSegmentService.call(user, transition)
         end
 
         it 'calls SegmentService#track with proper arguments' do
-          allow(magic_segment_service).to receive(:identify).with(
+          expect_any_instance_of(SegmentService).to receive(:identify).with(
             state: 'won_sticker'
           )
-          allow(magic_segment_service).to receive(:identify).with(
-            pull_requests_count: 4
-          )
-          expect(magic_segment_service).to receive(:track).with(
+          expect_any_instance_of(SegmentService).to receive(:track).with(
             'user_won_sticker'
           )
           UserStateTransitionSegmentService.call(user, transition)
@@ -237,26 +211,20 @@ RSpec.describe UserStateTransitionSegmentService do
       let(:user) { FactoryBot.create(:user, :incompleted) }
 
       it 'calls SegmentService#identify with proper arguments' do
-        expect(magic_segment_service).to receive(:identify).with(
+        expect_any_instance_of(SegmentService).to receive(:identify).with(
           state: 'gifted_sticker'
         )
-        expect(magic_segment_service).to receive(:identify).with(
-          pull_requests_count: 3
-        )
-        allow(magic_segment_service).to receive(:track).with(
+        expect_any_instance_of(SegmentService).to receive(:track).with(
           'user_gifted_sticker'
         )
         UserStateTransitionSegmentService.call(user, transition)
       end
 
       it 'calls SegmentService#track with proper arguments' do
-        allow(magic_segment_service).to receive(:identify).with(
+        expect_any_instance_of(SegmentService).to receive(:identify).with(
           state: 'gifted_sticker'
         )
-        allow(magic_segment_service).to receive(:identify).with(
-          pull_requests_count: 3
-        )
-        expect(magic_segment_service).to receive(:track).with(
+        expect_any_instance_of(SegmentService).to receive(:track).with(
           'user_gifted_sticker'
         )
         UserStateTransitionSegmentService.call(user, transition)

--- a/spec/services/user_state_transition_segment_service_spec.rb
+++ b/spec/services/user_state_transition_segment_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe UserStateTransitionSegmentService do
 
   before do
     allow(UserPullRequestSegmentUpdaterService)
-        .to receive(:call).and_return(true)
+      .to receive(:call).and_return(true)
   end
 
   describe '.call' do

--- a/spec/services/user_state_transition_segment_service_spec.rb
+++ b/spec/services/user_state_transition_segment_service_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe UserStateTransitionSegmentService do
   let(:transition) { double }
+  let(:magic_segment_service) { magic_instance_of(SegmentService) }
 
   describe '.call' do
     context 'the transition event is register and the user is new' do
@@ -20,7 +21,8 @@ RSpec.describe UserStateTransitionSegmentService do
           intel_marketing_emails: user.intel_marketing_emails,
           dev_marketing_emails: user.dev_marketing_emails,
           category: user.category,
-          state: 'register'
+          state: 'register',
+          pull_requests_count: 0
         )
         allow_any_instance_of(SegmentService).to receive(:track).with(
           'register'
@@ -35,7 +37,8 @@ RSpec.describe UserStateTransitionSegmentService do
           intel_marketing_emails: user.intel_marketing_emails,
           dev_marketing_emails: user.dev_marketing_emails,
           category: user.category,
-          state: 'register'
+          state: 'register',
+          pull_requests_count: 0
         )
         expect_any_instance_of(SegmentService).to receive(:track).with(
           'register'
@@ -52,20 +55,26 @@ RSpec.describe UserStateTransitionSegmentService do
       end
 
       it 'calls SegmentService#identify with proper arguments' do
-        allow_any_instance_of(SegmentService).to receive(:track).with(
-          'user_completed'
-        )
-        expect_any_instance_of(SegmentService).to receive(:identify).with(
+        expect(magic_segment_service).to receive(:identify).with(
           state: 'completed'
+        )
+        expect(magic_segment_service).to receive(:identify).with(
+          pull_requests_count: 4
+        )
+        allow(magic_segment_service).to receive(:track).with(
+          'user_completed'
         )
         UserStateTransitionSegmentService.call(user, transition)
       end
 
       it 'calls SegmentService#track with proper arguments' do
-        allow_any_instance_of(SegmentService).to receive(:identify).with(
+        allow(magic_segment_service).to receive(:identify).with(
           state: 'completed'
         )
-        expect_any_instance_of(SegmentService).to receive(:track).with(
+        allow(magic_segment_service).to receive(:identify).with(
+          pull_requests_count: 4
+        )
+        expect(magic_segment_service).to receive(:track).with(
           'user_completed'
         )
         UserStateTransitionSegmentService.call(user, transition)
@@ -81,20 +90,26 @@ RSpec.describe UserStateTransitionSegmentService do
       let(:user) { FactoryBot.create(:user, :incompleted) }
 
       it 'calls SegmentService#identify with proper arguments' do
-        allow_any_instance_of(SegmentService).to receive(:track).with(
-          'user_completed'
-        )
-        expect_any_instance_of(SegmentService).to receive(:identify).with(
+        expect(magic_segment_service).to receive(:identify).with(
           state: 'completed'
+        )
+        expect(magic_segment_service).to receive(:identify).with(
+          pull_requests_count: 3,
+        )
+        allow(magic_segment_service).to receive(:track).with(
+          'user_completed'
         )
         UserStateTransitionSegmentService.call(user, transition)
       end
 
       it 'calls SegmentService#track with proper arguments' do
-        allow_any_instance_of(SegmentService).to receive(:identify).with(
+        allow(magic_segment_service).to receive(:identify).with(
           state: 'completed'
         )
-        expect_any_instance_of(SegmentService).to receive(:track).with(
+        allow(magic_segment_service).to receive(:identify).with(
+          pull_requests_count: 3,
+        )
+        expect(magic_segment_service).to receive(:track).with(
           'user_completed'
         )
         UserStateTransitionSegmentService.call(user, transition)
@@ -111,20 +126,26 @@ RSpec.describe UserStateTransitionSegmentService do
       end
 
       it 'calls SegmentService#identify with proper arguments' do
-        allow_any_instance_of(SegmentService).to receive(:track).with(
-          'user_insufficient'
-        )
-        expect_any_instance_of(SegmentService).to receive(:identify).with(
+        expect(magic_segment_service).to receive(:identify).with(
           state: 'insufficient'
+        )
+        expect(magic_segment_service).to receive(:identify).with(
+          pull_requests_count: 4,
+        )
+        allow(magic_segment_service).to receive(:track).with(
+          'user_insufficient'
         )
         UserStateTransitionSegmentService.call(user, transition)
       end
 
       it 'calls SegmentService#track with proper arguments' do
-        allow_any_instance_of(SegmentService).to receive(:identify).with(
+        allow(magic_segment_service).to receive(:identify).with(
           state: 'insufficient'
         )
-        expect_any_instance_of(SegmentService).to receive(:track).with(
+        allow(magic_segment_service).to receive(:identify).with(
+          pull_requests_count: 4,
+        )
+        expect(magic_segment_service).to receive(:track).with(
           'user_insufficient'
         )
         UserStateTransitionSegmentService.call(user, transition)
@@ -146,20 +167,26 @@ RSpec.describe UserStateTransitionSegmentService do
         end
 
         it 'calls SegmentService#identify with proper arguments' do
-          expect_any_instance_of(SegmentService).to receive(:identify).with(
+          expect(magic_segment_service).to receive(:identify).with(
             state: 'won_shirt'
           )
-          expect_any_instance_of(SegmentService).to receive(:track).with(
+          expect(magic_segment_service).to receive(:identify).with(
+            pull_requests_count: 4,
+          )
+          allow(magic_segment_service).to receive(:track).with(
             'user_won_shirt'
           )
           UserStateTransitionSegmentService.call(user, transition)
         end
 
         it 'calls SegmentService#track with proper arguments' do
-          expect_any_instance_of(SegmentService).to receive(:identify).with(
+          allow(magic_segment_service).to receive(:identify).with(
             state: 'won_shirt'
           )
-          expect_any_instance_of(SegmentService).to receive(:track).with(
+          allow(magic_segment_service).to receive(:identify).with(
+            pull_requests_count: 4,
+          )
+          expect(magic_segment_service).to receive(:track).with(
             'user_won_shirt'
           )
           UserStateTransitionSegmentService.call(user, transition)
@@ -174,20 +201,26 @@ RSpec.describe UserStateTransitionSegmentService do
         end
 
         it 'calls SegmentService#identify with proper arguments' do
-          expect_any_instance_of(SegmentService).to receive(:identify).with(
+          expect(magic_segment_service).to receive(:identify).with(
             state: 'won_sticker'
           )
-          expect_any_instance_of(SegmentService).to receive(:track).with(
+          expect(magic_segment_service).to receive(:identify).with(
+            pull_requests_count: 4,
+          )
+          allow(magic_segment_service).to receive(:track).with(
             'user_won_sticker'
           )
           UserStateTransitionSegmentService.call(user, transition)
         end
 
         it 'calls SegmentService#track with proper arguments' do
-          expect_any_instance_of(SegmentService).to receive(:identify).with(
+          allow(magic_segment_service).to receive(:identify).with(
             state: 'won_sticker'
           )
-          expect_any_instance_of(SegmentService).to receive(:track).with(
+          allow(magic_segment_service).to receive(:identify).with(
+            pull_requests_count: 4,
+          )
+          expect(magic_segment_service).to receive(:track).with(
             'user_won_sticker'
           )
           UserStateTransitionSegmentService.call(user, transition)
@@ -204,20 +237,26 @@ RSpec.describe UserStateTransitionSegmentService do
       let(:user) { FactoryBot.create(:user, :incompleted) }
 
       it 'calls SegmentService#identify with proper arguments' do
-        expect_any_instance_of(SegmentService).to receive(:identify).with(
+        expect(magic_segment_service).to receive(:identify).with(
           state: 'gifted_sticker'
         )
-        expect_any_instance_of(SegmentService).to receive(:track).with(
+        expect(magic_segment_service).to receive(:identify).with(
+          pull_requests_count: 3,
+        )
+        allow(magic_segment_service).to receive(:track).with(
           'user_gifted_sticker'
         )
         UserStateTransitionSegmentService.call(user, transition)
       end
 
       it 'calls SegmentService#track with proper arguments' do
-        expect_any_instance_of(SegmentService).to receive(:identify).with(
+        allow(magic_segment_service).to receive(:identify).with(
           state: 'gifted_sticker'
         )
-        expect_any_instance_of(SegmentService).to receive(:track).with(
+        allow(magic_segment_service).to receive(:identify).with(
+          pull_requests_count: 3,
+        )
+        expect(magic_segment_service).to receive(:track).with(
           'user_gifted_sticker'
         )
         UserStateTransitionSegmentService.call(user, transition)

--- a/spec/services/user_state_transition_segment_service_spec.rb
+++ b/spec/services/user_state_transition_segment_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe UserStateTransitionSegmentService do
       end
 
       it 'calls SegmentService#identify with proper arguments' do
-        expect_any_instance_of(SegmentService).to receive(:identify).with(
+        expect(magic_segment_service).to receive(:identify).with(
           email: user.email,
           digitalocean_marketing_emails: user.digitalocean_marketing_emails,
           intel_marketing_emails: user.intel_marketing_emails,
@@ -24,14 +24,14 @@ RSpec.describe UserStateTransitionSegmentService do
           state: 'register',
           pull_requests_count: 0
         )
-        allow_any_instance_of(SegmentService).to receive(:track).with(
+        allow(magic_segment_service).to receive(:track).with(
           'register'
         )
         UserStateTransitionSegmentService.call(user, transition)
       end
 
       it 'calls SegmentService#track with proper arguments' do
-        allow_any_instance_of(SegmentService).to receive(:identify).with(
+        allow(magic_segment_service).to receive(:identify).with(
           email: user.email,
           digitalocean_marketing_emails: user.digitalocean_marketing_emails,
           intel_marketing_emails: user.intel_marketing_emails,
@@ -40,7 +40,7 @@ RSpec.describe UserStateTransitionSegmentService do
           state: 'register',
           pull_requests_count: 0
         )
-        expect_any_instance_of(SegmentService).to receive(:track).with(
+        expect(magic_segment_service).to receive(:track).with(
           'register'
         )
         UserStateTransitionSegmentService.call(user, transition)
@@ -94,7 +94,7 @@ RSpec.describe UserStateTransitionSegmentService do
           state: 'completed'
         )
         expect(magic_segment_service).to receive(:identify).with(
-          pull_requests_count: 3,
+          pull_requests_count: 3
         )
         allow(magic_segment_service).to receive(:track).with(
           'user_completed'
@@ -107,7 +107,7 @@ RSpec.describe UserStateTransitionSegmentService do
           state: 'completed'
         )
         allow(magic_segment_service).to receive(:identify).with(
-          pull_requests_count: 3,
+          pull_requests_count: 3
         )
         expect(magic_segment_service).to receive(:track).with(
           'user_completed'
@@ -130,7 +130,7 @@ RSpec.describe UserStateTransitionSegmentService do
           state: 'insufficient'
         )
         expect(magic_segment_service).to receive(:identify).with(
-          pull_requests_count: 4,
+          pull_requests_count: 4
         )
         allow(magic_segment_service).to receive(:track).with(
           'user_insufficient'
@@ -143,7 +143,7 @@ RSpec.describe UserStateTransitionSegmentService do
           state: 'insufficient'
         )
         allow(magic_segment_service).to receive(:identify).with(
-          pull_requests_count: 4,
+          pull_requests_count: 4
         )
         expect(magic_segment_service).to receive(:track).with(
           'user_insufficient'
@@ -171,7 +171,7 @@ RSpec.describe UserStateTransitionSegmentService do
             state: 'won_shirt'
           )
           expect(magic_segment_service).to receive(:identify).with(
-            pull_requests_count: 4,
+            pull_requests_count: 4
           )
           allow(magic_segment_service).to receive(:track).with(
             'user_won_shirt'
@@ -184,7 +184,7 @@ RSpec.describe UserStateTransitionSegmentService do
             state: 'won_shirt'
           )
           allow(magic_segment_service).to receive(:identify).with(
-            pull_requests_count: 4,
+            pull_requests_count: 4
           )
           expect(magic_segment_service).to receive(:track).with(
             'user_won_shirt'
@@ -205,7 +205,7 @@ RSpec.describe UserStateTransitionSegmentService do
             state: 'won_sticker'
           )
           expect(magic_segment_service).to receive(:identify).with(
-            pull_requests_count: 4,
+            pull_requests_count: 4
           )
           allow(magic_segment_service).to receive(:track).with(
             'user_won_sticker'
@@ -218,7 +218,7 @@ RSpec.describe UserStateTransitionSegmentService do
             state: 'won_sticker'
           )
           allow(magic_segment_service).to receive(:identify).with(
-            pull_requests_count: 4,
+            pull_requests_count: 4
           )
           expect(magic_segment_service).to receive(:track).with(
             'user_won_sticker'
@@ -241,7 +241,7 @@ RSpec.describe UserStateTransitionSegmentService do
           state: 'gifted_sticker'
         )
         expect(magic_segment_service).to receive(:identify).with(
-          pull_requests_count: 3,
+          pull_requests_count: 3
         )
         allow(magic_segment_service).to receive(:track).with(
           'user_gifted_sticker'
@@ -254,7 +254,7 @@ RSpec.describe UserStateTransitionSegmentService do
           state: 'gifted_sticker'
         )
         allow(magic_segment_service).to receive(:identify).with(
-          pull_requests_count: 3,
+          pull_requests_count: 3
         )
         expect(magic_segment_service).to receive(:track).with(
           'user_gifted_sticker'

--- a/spec/support/pull_request_filter_helper.rb
+++ b/spec/support/pull_request_filter_helper.rb
@@ -433,8 +433,8 @@ module PullRequestFilterHelper
     GithubPullRequest.new(Hashie::Mash.new(hash))
   end
 
-  def pr_stub_helper(target, pr_data)
-    PullRequest.delete_all
+  def pr_stub_helper(target, pr_data, clear = true)
+    PullRequest.delete_all if clear
     allow(target.send(:pull_request_service))
       .to receive(:github_pull_requests)
       .and_return(pull_request_data(pr_data))


### PR DESCRIPTION
# Description

Whenever a new PR is created in the database, we need to update the user in Segment to have the correct PR count. This PR achieves this by watching for new PRs in the PR service and then updating Segment.

# Test process

Added debug `puts` into `UserPullRequestSegmentUpdaterService#call`, signed up as a new user. Observed single call made to `UserPullRequestSegmentUpdaterService#call` once all the new PRs were added in the DB.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
