### PR TITLE
Track spam repo report count

### DIFF
--- a/app/services/report_airtable_updater_service.rb
+++ b/app/services/report_airtable_updater_service.rb
@@ -8,6 +8,7 @@ module ReportAirtableUpdaterService
       # Existing record, update it
       if (existing_record = spammy_repo_report(repository.id))
         existing_record["Reports"] += 1
+        existing_record["Year"] = Hacktoberfest.start_date.year
         existing_record.save
         return existing_record
       end

--- a/app/services/report_airtable_updater_service.rb
+++ b/app/services/report_airtable_updater_service.rb
@@ -5,10 +5,20 @@ module ReportAirtableUpdaterService
 
   def call(report)
     if (repository = github_client.repository(report.github_repo_identifier))
-      return if spammy_repo_report_exists?(repository.id)
+      # Existing record, update it
+      if (existing_record = spammy_repo_report(repository.id))
+        existing_record["Reports"] += 1
+        existing_record.save
+        return existing_record
+      end
 
-      # mark it as spam
-      new_record = { "Repo ID": repository.id.to_s, "Repo Link": report.url }
+      # Create a new record to mark it as spam
+      new_record = {
+        "Repo ID": repository.id.to_s,
+        "Repo Link": report.url,
+        Reports: 1,
+        Year: Hacktoberfest.start_date.year,
+      }
       AirrecordTable.new.table('Spam Repos').create(new_record)
     end
   rescue Octokit::NotFound, Octokit::InvalidRepository
@@ -19,12 +29,9 @@ module ReportAirtableUpdaterService
     Octokit::Client.new(access_token: GithubTokenService.random)
   end
 
-  def spammy_repo_report_exists?(repo_id)
-    previously_reported_repo_ids = AirrecordTable.new.all_records(
-      'Spam Repos'
-    ).map do |repo|
-      repo['Repo ID']&.to_i if repo['Verified?'] || repo['Permitted?']
-    end.compact
-    previously_reported_repo_ids.include?(repo_id)
+  def spammy_repo_report(repo_id)
+    AirrecordTable.new.all_records('Spam Repos')
+      .select { |repo| repo['Repo ID']&.to_i == repo_id }
+      .first
   end
 end

--- a/app/services/report_airtable_updater_service.rb
+++ b/app/services/report_airtable_updater_service.rb
@@ -7,8 +7,8 @@ module ReportAirtableUpdaterService
     if (repository = github_client.repository(report.github_repo_identifier))
       # Existing record, update it
       if (existing_record = spammy_repo_report(repository.id))
-        existing_record["Reports"] += 1
-        existing_record["Year"] = Hacktoberfest.start_date.year
+        existing_record['Reports'] += 1
+        existing_record['Year'] = Hacktoberfest.start_date.year
         existing_record.save
         return existing_record
       end
@@ -18,7 +18,7 @@ module ReportAirtableUpdaterService
         "Repo ID": repository.id.to_s,
         "Repo Link": report.url,
         Reports: 1,
-        Year: Hacktoberfest.start_date.year,
+        Year: Hacktoberfest.start_date.year
       }
       AirrecordTable.new.table('Spam Repos').create(new_record)
     end
@@ -32,7 +32,7 @@ module ReportAirtableUpdaterService
 
   def spammy_repo_report(repo_id)
     AirrecordTable.new.all_records('Spam Repos')
-      .select { |repo| repo['Repo ID']&.to_i == repo_id }
-      .first
+                  .select { |repo| repo['Repo ID']&.to_i == repo_id }
+                  .first
   end
 end

--- a/spec/services/report_airtable_updater_service_spec.rb
+++ b/spec/services/report_airtable_updater_service_spec.rb
@@ -34,7 +34,9 @@ describe ReportAirtableUpdaterService do
           ReportAirtableUpdaterService.call(report)
         end
 
-        it 'does not write to airtable', :vcr do
+        # This will now write to Airtable with an updated report count
+        # Testing this requires faking an existing Airtable record instance etc.
+        xit 'does not write to airtable', :vcr do
           expect(a_request(:post, AIRTABLE_URI_REGEX)).to_not have_been_made
         end
       end

--- a/spec/services/report_airtable_updater_service_spec.rb
+++ b/spec/services/report_airtable_updater_service_spec.rb
@@ -25,28 +25,29 @@ describe ReportAirtableUpdaterService do
         Report.new(url: 'https://github.com/raise-dev/hacktoberfest-test')
       end
 
-      context 'the repository is already known to be spam' do
-        before do
-          existent_repo_id = 211_178_535
-          allow(ReportAirtableUpdaterService)
-            .to receive(:spammy_repo_report_exists?)
-            .with(existent_repo_id).and_return(true)
-          ReportAirtableUpdaterService.call(report)
-        end
-
-        # This will now write to Airtable with an updated report count
-        # Testing this requires faking an existing Airtable record instance etc.
-        xit 'does not write to airtable', :vcr do
-          expect(a_request(:post, AIRTABLE_URI_REGEX)).to_not have_been_made
-        end
-      end
+      # This will now write to Airtable with an updated report count
+      # Testing this requires faking an existing Airtable record instance etc.
+      # context 'the repository is already known to be spam' do
+      #   before do
+      #     existent_repo_id = 211_178_535
+      #     # FIXME: This needs to return a fake Airtable record
+      #     allow(ReportAirtableUpdaterService)
+      #       .to receive(:spammy_repo_report)
+      #       .with(existent_repo_id).and_return({})
+      #     ReportAirtableUpdaterService.call(report)
+      #   end
+      #
+      #   it 'does not write to airtable', :vcr do
+      #     expect(a_request(:post, AIRTABLE_URI_REGEX)).to_not have_been_made
+      #   end
+      # end
 
       context 'the repository is not already marked as spam' do
         before do
           new_repo_id = 211_178_535
           allow(ReportAirtableUpdaterService)
-            .to receive(:spammy_repo_report_exists?)
-            .with(new_repo_id).and_return(false)
+            .to receive(:spammy_repo_report)
+            .with(new_repo_id).and_return(nil)
           ReportAirtableUpdaterService.call(report)
         end
 

--- a/spec/vcr/ReportAirtableUpdaterService/_call/the_repository_does_exist/the_repository_is_not_already_marked_as_spam/writes_to_airtable.yml
+++ b/spec/vcr/ReportAirtableUpdaterService/_call/the_repository_does_exist/the_repository_is_not_already_marked_as_spam/writes_to_airtable.yml
@@ -84,7 +84,7 @@ http_interactions:
     uri: https://api.airtable.com/v0/<TEST_AIRTABLE_APP_ID>/Spam%20Repos
     body:
       encoding: UTF-8
-      string: '{"fields":{"Repo ID":"211178535","Repo Link":"https://github.com/raise-dev/hacktoberfest-test"}}'
+      string: '{"fields":{"Repo ID":"211178535","Repo Link":"https://github.com/raise-dev/hacktoberfest-test","Reports":1,"Year":2020}}'
     headers:
       Authorization:
       - Bearer <TEST_AIRTABLE_API_KEY>
@@ -134,7 +134,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"id":"rec2D2ZbcCeVqqaHL","fields":{"Repo ID":"211178535","Repo Link":"https://github.com/raise-dev/hacktoberfest-test"},"createdTime":"2019-11-12T17:03:01.000Z"}'
+      string: '{"id":"rec2D2ZbcCeVqqaHL","fields":{"Repo ID":"211178535","Repo Link":"https://github.com/raise-dev/hacktoberfest-test","Reports":1,"Year":2020},"createdTime":"2019-11-12T17:03:01.000Z"}'
     http_version: 
   recorded_at: Tue, 12 Nov 2019 17:03:00 GMT
 - request:


### PR DESCRIPTION
# Description

Instead of creating duplicate records for unverified reports and not creating a new record if the repo is already verified, always have a single record for each repository that is reported and update the report count if it is reported again.

# Test process

- Report new repository, check record created in Airtable
- Report existing repository, check record updated in Airtablr

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
