### PR TITLE
Only show main + pre-launch FAQs

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -21,7 +21,7 @@ class PagesController < ApplicationController
     rescue StandardError
       faqs = AirtablePlaceholderService.call('FAQs')
     end
-    present_faqs(faqs)
+    present_faqs(filter_faqs(faqs))
   end
 
   def events
@@ -59,6 +59,13 @@ class PagesController < ApplicationController
       { amount: '154,466', title: 'PARTICIPATING REPOSITORIES' }
     ]
     stats_arr.map { |s| Hashie::Mash.new(s) }
+  end
+
+  def filter_faqs(faqs)
+    faqs.select do |faq|
+      stages = faq['Site Stage'].map(&:strip)
+      stages.include?('Main') || stages.include?('Pre Launch')
+    end
   end
 
   def present_faqs(faqs)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -87,7 +87,6 @@ class PagesController < ApplicationController
     @faqs_shipping = faqs.select { |q| q['Category'] == 'Shipping' }
   end
 
-
   def faq_item(faq)
     [faq['Category'].strip, faq['Question'].strip]
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -62,10 +62,6 @@ class PagesController < ApplicationController
   end
 
   def filter_faqs(faqs)
-    def faq_item(faq)
-      [ faq['Category'].strip, faq['Question'].strip ]
-    end
-
     # Get all the main FAQs
     main = faqs.select do |faq|
       faq['Site Stage'].map(&:strip).include?('Main')
@@ -77,7 +73,7 @@ class PagesController < ApplicationController
     # Get pre launch FAQs that aren't in main
     pre_launch = faqs.select do |faq|
       faq['Site Stage'].map(&:strip).include?('Pre Launch') &&
-          !main_qs.include?(faq_item(faq))
+        !main_qs.include?(faq_item(faq))
     end
 
     # Combine main + extras from pre launch
@@ -89,5 +85,10 @@ class PagesController < ApplicationController
     @faqs_general = faqs.select { |q| q['Category'] == 'General' }
     @faqs_events = faqs.select { |q| q['Category'] == 'Events' }
     @faqs_shipping = faqs.select { |q| q['Category'] == 'Shipping' }
+  end
+
+
+  def faq_item(faq)
+    [faq['Category'].strip, faq['Question'].strip]
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -62,10 +62,26 @@ class PagesController < ApplicationController
   end
 
   def filter_faqs(faqs)
-    faqs.select do |faq|
-      stages = faq['Site Stage'].map(&:strip)
-      stages.include?('Main') || stages.include?('Pre Launch')
+    def faq_item(faq)
+      [ faq['Category'].strip, faq['Question'].strip ]
     end
+
+    # Get all the main FAQs
+    main = faqs.select do |faq|
+      faq['Site Stage'].map(&:strip).include?('Main')
+    end
+
+    # Get the category & question for each item in main
+    main_qs = main.map { |faq| faq_item(faq) }
+
+    # Get pre launch FAQs that aren't in main
+    pre_launch = faqs.select do |faq|
+      faq['Site Stage'].map(&:strip).include?('Pre Launch') &&
+          !main_qs.include?(faq_item(faq))
+    end
+
+    # Combine main + extras from pre launch
+    main + pre_launch
   end
 
   def present_faqs(faqs)


### PR DESCRIPTION
# Description

Only show FAQs from the main and pre-launch site stages, not the original teaser FAQs.

# Test process

Verified teaser FAQs in Airtable were not displayed on the site

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
