### PR TITLE
Add sidekiq task for project importing on homepage

### DIFF
--- a/app/jobs/project_import_job.rb
+++ b/app/jobs/project_import_job.rb
@@ -6,5 +6,7 @@ class ProjectImportJob
 
   def perform(query_string = nil)
     ProjectImportService.call(query_string)
+  rescue
+    # Ignored
   end
 end

--- a/app/jobs/project_import_job.rb
+++ b/app/jobs/project_import_job.rb
@@ -6,7 +6,7 @@ class ProjectImportJob
 
   def perform(query_string = nil)
     ProjectImportService.call(query_string)
-  rescue
+  rescue StandardError
     # Ignored
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -29,3 +29,8 @@
     class: FetchSpamRepositoriesJob
     queue: default
     description: 'Updates spam repos every 15 minutes'
+  :homepage_project_import:
+    cron: '0 0 * * * America/New_York'
+    class: ProjectImportJob
+    queue: default
+    description: 'Updates the projects displayed on the homepage'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -9,6 +9,11 @@
     class: TransitionAllUsersJob
     queue: critical
     description: 'This job transitions users every two hours'
+  :homepage_project_import:
+    cron: '0 1 * * * America/New_York'
+    class: ProjectImportJob
+    queue: default
+    description: 'This job updates the projects displayed on the homepage every day at 1AM'
   :update_all_issues:
     cron: '0 3 * * * America/New_York'
     class: UpdateAllIssuesJob
@@ -29,8 +34,3 @@
     class: FetchSpamRepositoriesJob
     queue: default
     description: 'Updates spam repos every 15 minutes'
-  :homepage_project_import:
-    cron: '0 0 * * * America/New_York'
-    class: ProjectImportJob
-    queue: default
-    description: 'Updates the projects displayed on the homepage'


### PR DESCRIPTION
# Description

There is no rake task for this, it appears to need to be run as a job.

# Test process

Called the service directly, it sometimes runs without error.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
