### PR TITLE
Multi-select roles in register, edit roles + country

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,7 @@ class UsersController < ApplicationController
   before_action :require_user_registered!, only: :show
   before_action :disallow_registered_user!, only: :registration
   before_action :transform_categories, only: %i[register update]
+  before_action :set_dropdowns, only: %i[registration edit]
 
   # render current user profile
   def show
@@ -18,31 +19,27 @@ class UsersController < ApplicationController
     if save_or_register(@current_user)
       redirect_to profile_path
     else
-      set_user_emails
+      set_dropdowns
       render 'users/registration'
     end
   end
 
-  # action to render register form
-  def registration
-    @categories = { 'Participant' => 'participant',
-                    'Event Organizer' => 'organizer',
-                    'Maintainer' => 'maintainer' }
-    set_user_emails
-  end
+  def registration; end
 
-  def edit
-    set_user_emails
-  end
+  def edit; end
 
   def update
     @current_user.assign_attributes(params_for_update)
     if @current_user.save
       segment = SegmentService.new(@current_user)
-      segment.identify(email: @current_user.email)
+      segment.identify(
+          email: @current_user.email,
+          category: @current_user.category,
+          country: @current_user.country
+      )
       redirect_to profile_path
     else
-      set_user_emails
+      set_dropdowns
       render 'users/edit'
     end
   end
@@ -57,8 +54,11 @@ class UsersController < ApplicationController
     end
   end
 
-  def set_user_emails
+  def set_dropdowns
     @emails = UserEmailService.new(@current_user).emails
+    @categories = { 'Participant' => 'participant',
+                    'Event Organizer' => 'organizer',
+                    'Maintainer' => 'maintainer' }
   end
 
   def transform_categories
@@ -82,6 +82,10 @@ class UsersController < ApplicationController
   end
 
   def params_for_update
-    params.require(:user).permit(:email)
+    params.require(:user).permit(
+:email,
+      :category,
+      :country
+    )
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,9 +33,9 @@ class UsersController < ApplicationController
     if @current_user.save
       segment = SegmentService.new(@current_user)
       segment.identify(
-          email: @current_user.email,
-          category: @current_user.category,
-          country: @current_user.country
+        email: @current_user.email,
+        category: @current_user.category,
+        country: @current_user.country
       )
       redirect_to profile_path
     else
@@ -62,11 +62,11 @@ class UsersController < ApplicationController
   end
 
   def transform_categories
-    if params[:user].present? && params[:user][:category].present?
-      params[:user][:category] = params[:user][:category]
-                                     .reject(&:empty?)
-                                     .join(',')
-      end
+    return unless params[:user].present? && params[:user][:category].present?
+
+    params[:user][:category] = params[:user][:category]
+                               .reject(&:empty?)
+                               .join(',')
   end
 
   def params_for_registration
@@ -83,7 +83,7 @@ class UsersController < ApplicationController
 
   def params_for_update
     params.require(:user).permit(
-:email,
+      :email,
       :category,
       :country
     )

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < ApplicationController
   before_action :require_user_logged_in!
   before_action :require_user_registered!, only: :show
   before_action :disallow_registered_user!, only: :registration
+  before_action :transform_categories, only: %i[register update]
 
   # render current user profile
   def show
@@ -24,7 +25,7 @@ class UsersController < ApplicationController
 
   # action to render register form
   def registration
-    @categories = { 'Participant' => 'Participant',
+    @categories = { 'Participant' => 'participant',
                     'Event Organizer' => 'organizer',
                     'Maintainer' => 'maintainer' }
     set_user_emails
@@ -58,6 +59,14 @@ class UsersController < ApplicationController
 
   def set_user_emails
     @emails = UserEmailService.new(@current_user).emails
+  end
+
+  def transform_categories
+    if params[:user].present? && params[:user][:category].present?
+      params[:user][:category] = params[:user][:category]
+                                     .reject(&:empty?)
+                                     .join(',')
+      end
   end
 
   def params_for_registration

--- a/app/views/users/_dropdowns.html.erb
+++ b/app/views/users/_dropdowns.html.erb
@@ -1,0 +1,44 @@
+<div class="dropdowns">
+  <div class="field">
+    <div class="control">
+      <div class="select">
+        <%= f.select :email, @emails,
+                     {
+                         include_blank: 'Select your preferred email address...',
+                         selected: u.email
+                     },
+                     {
+                         :required => true
+                     } %>
+      </div>
+    </div>
+  </div>
+
+  <div class="field">
+    <div class="control">
+      <div class="select is-multiple">
+        <%= f.select :category, @categories,
+                     {
+                         include_blank: 'Select all roles that apply to you...',
+                         selected: (u.category || '').split(',')
+                     },
+                     {
+                         :required => true,
+                         :multiple => true
+                     } %>
+      </div>
+    </div>
+  </div>
+
+  <div class="field">
+    <div class="control">
+      <div class="select">
+        <%= f.country_select :country,
+                             {
+                                 include_blank: 'Optional: Select your country...',
+                                 selected: u.country
+                             } %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,23 +1,22 @@
 <section class="section reg-content">
-  <div>
-    <h1 class="title is-1">About you</h1>
-    <p>
-      Please select which email address you'd like
-      to use for Hacktoberfest:
-    </p>
-    <%= form_for :user, url: { action: 'update' }, method: :patch do |f| %>
+  <div class="container">
+    <div class="registration-wrapper">
+      <div class="registration-left">
+        <h1 class="title is-1">About you</h1>
+        <p>
+          Please select which email address you'd like to use for Hacktoberfest:
+        </p>
 
-      <div class="field">
-        <label class="label">Preferred email</label>
-        <div class="control">
-          <div class="select">
-            <%= f.select :email, @emails %>
-          </div>
-        </div>
+        <%= form_for :user, url: { action: 'update' }, method: :patch do |f| %>
+          <%= render partial: 'users/dropdowns', locals: { f: f, u: @current_user } %>
+
+          <%= f.submit 'Update profile', :class => 'button-static'%>
+        <% end %>
       </div>
 
-      <%= f.submit 'Update email', :class => 'button-static'%>
-
-    <% end %>
+      <div class="registration-right">
+        <div class="background-img"></div>
+      </div>
+    </div>
   </div>
 </section>

--- a/app/views/users/registration.html.erb
+++ b/app/views/users/registration.html.erb
@@ -10,31 +10,7 @@
         </p>
 
         <%= form_for :user, url: {action: 'register'}, method: :patch do |f| %>
-          <div class="dropdowns">
-            <div class="field">
-              <div class="control">
-                <div class="select">
-                  <%= f.select :email, @emails, {include_blank: 'Select your preferred email address...'}, {:required => true} %>
-                </div>
-              </div>
-            </div>
-
-            <div class="field">
-              <div class="control">
-                <div class="select is-multiple">
-                  <%= f.select :category, @categories, {include_blank: 'Select all roles that apply to you...'}, {:required => true, :multiple => true} %>
-                </div>
-              </div>
-            </div>
-
-            <div class="field">
-              <div class="control">
-                <div class="select">
-                  <%= f.country_select :country, {include_blank: 'Optional: Select your country...'} %>
-                </div>
-              </div>
-            </div>
-          </div>
+          <%= render partial: 'users/dropdowns', locals: { f: f, u: User.new } %>
 
           <div class="checkboxes">
             <div class="field">

--- a/app/views/users/registration.html.erb
+++ b/app/views/users/registration.html.erb
@@ -6,7 +6,7 @@
         <h1 class="title is-1">About you</h1>
         <p>
           Please select which email address you’d like to use for Hacktoberfest and read the
-          <a target="_blank" href="/details#participation-rules">rules and values</a>.
+          <a target="_blank" href="/details#rules">rules and values</a>.
         </p>
 
         <%= form_for :user, url: {action: 'register'}, method: :patch do |f| %>
@@ -14,7 +14,15 @@
             <div class="field">
               <div class="control">
                 <div class="select">
-                  <%= f.select :email, @emails, {include_blank: 'Select preferred email address'}, {:required => true} %>
+                  <%= f.select :email, @emails, {include_blank: 'Select your preferred email address...'}, {:required => true} %>
+                </div>
+              </div>
+            </div>
+
+            <div class="field">
+              <div class="control">
+                <div class="select is-multiple">
+                  <%= f.select :category, @categories, {include_blank: 'Select all roles that apply to you...'}, {:required => true, :multiple => true} %>
                 </div>
               </div>
             </div>
@@ -22,15 +30,7 @@
             <div class="field">
               <div class="control">
                 <div class="select">
-                  <%= f.select :category, @categories, {include_blank: 'Select your role'}, {:required => true} %>
-                </div>
-              </div>
-            </div>
-
-            <div class="field">
-              <div class="control">
-                <div class="select">
-                  <%= f.country_select :country, {include_blank: 'Optional: Select your country'} %>
+                  <%= f.country_select :country, {include_blank: 'Optional: Select your country...'} %>
                 </div>
               </div>
             </div>
@@ -75,7 +75,7 @@
               <label class="checkbox">
                 <%= f.check_box :terms_acceptance, {:class => 'check-style', :required => true} %>
                 I have read and understand the
-                <a target="_blank" href="/details#participation-rules">Rules and Values</a>.
+                <a target="_blank" href="/details#rules">Rules and Values</a>.
               </label>
             </div>
           </div>


### PR DESCRIPTION
# Description

Update the roles selection in registration to be multi-select, stored as a comma-separated string.

Update profile edit to allow the editing of user's roles + country.

# Test process

Sign up, select more than one role.

Go to /profile/edit, confirm existing data is shown as selected, confirm updating & saving works.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
