### PR TITLE
Use events view link, not register

### DIFF
--- a/app/presenters/mlh_event_presenter.rb
+++ b/app/presenters/mlh_event_presenter.rb
@@ -39,7 +39,7 @@ class MlhEventPresenter
   end
 
   def url
-    @event.dig('links', 'register')
+    @event.dig('links', 'view')
   end
 
   def current?

--- a/spec/presenters/mlh_event_presenter_spec.rb
+++ b/spec/presenters/mlh_event_presenter_spec.rb
@@ -18,7 +18,8 @@ describe MlhEventPresenter do
             }
           },
           'links' => {
-            'register' => 'http://organize.mlh.io/participants/events/3921-hacktoberfest-in-brasilia/register'
+            'register' => 'http://organize.mlh.io/participants/events/3921-hacktoberfest-in-brasilia/register',
+            'view' => 'http://organize.mlh.io/participants/events/3921-hacktoberfest-in-brasilia'
           }
         }
       end
@@ -35,7 +36,7 @@ describe MlhEventPresenter do
           event.dig('attributes', 'location', 'city'),
           event.dig('attributes', 'location', 'country')
         )
-        expect(event_presenter.url).to eq event.dig('links', 'register')
+        expect(event_presenter.url).to eq event.dig('links', 'view')
       end
     end
 
@@ -68,6 +69,7 @@ describe MlhEventPresenter do
       end
     end
   end
+
   describe '#current?' do
     let(:event) do
       {
@@ -80,7 +82,8 @@ describe MlhEventPresenter do
           }
         },
         'links' => {
-          'register' => 'http://organize.mlh.io/participants/events/3921-hacktoberfest-in-brasilia/register'
+          'register' => 'http://organize.mlh.io/participants/events/3921-hacktoberfest-in-brasilia/register',
+          'view' => 'http://organize.mlh.io/participants/events/3921-hacktoberfest-in-brasilia'
         }
       }
     end


### PR DESCRIPTION
# Description

Use the view link for events so users aren't immediately thrown to sign in to MLH.

# Test process

Click RSVP for an event, goes to the event view page.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
