### PR TITLE
Drop nil values from GitHub response

### DIFF
--- a/app/services/github_pull_request_service.rb
+++ b/app/services/github_pull_request_service.rb
@@ -52,7 +52,7 @@ class GithubPullRequestService
       end
     end
 
-    @pull_requests = response.data.node.pullRequests.nodes.map do |pr|
+    @pull_requests = response.data.node.pullRequests.nodes.compact.map do |pr|
       GithubPullRequest.new(pr)
     end
   end


### PR DESCRIPTION
# Description

Drop nil values from GitHub response.

Should resolve `NoMethodError:  undefined method 'createdAt' for nil:NilClass` seen during registration for some users.

(Coming from `@graphql_hash.createdAt` in `github_pull_request.rb`, which would imply `@graphql_hash` is nil, so `GithubPullRequest` was instantiated with nil)

# Test process

N/A, no idea what the cause is.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
