### PR TITLE
Fix broken README link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Here are a few things that will help us help resolve your issues:
 ## Submitting a pull request
 
 0. Clone the repository
-0. Configure and install the dependencies: (See the [README](README) for more details)
+0. Configure and install the dependencies: (See the [README](README.md) for more details)
 0. Make sure the tests pass on your machine: `script/test`
 0. Create a new branch: `git checkout -b my-branch-name`
 0. Make your change, add tests, and make sure the tests still pass


### PR DESCRIPTION
# Description
CONTRIBUTING.md contained a broken link for README in Submitting a pull request section. The hyperlink directed towards [404 page](https://github.com/digitalocean/hacktoberfest/blob/master/README).
The fix was simply to add `.md` (extension of README in the URL).