### PR TITLE
Fix text saying first 75k instead of first 70k

### DIFF
--- a/app/views/pages/details.html.erb
+++ b/app/views/pages/details.html.erb
@@ -84,7 +84,7 @@
         be to any public repository on GitHub, not just the ones highlighted. The pull request must contain commits you
         made yourself. If a maintainer reports your pull request as spam, it will not be counted toward your
         participation in Hacktoberfest. If a maintainer reports behavior that’s not in line with the project’s code of
-        conduct, you will be ineligible to participate. This year, the first 75,000 participants can earn a T-shirt.</p>
+        conduct, you will be ineligible to participate. This year, the first 70,000 participants can earn a T-shirt.</p>
     </section>
 
     <section class="quality-standards">

--- a/app/views/pages/homepage/active_homepage.html.erb
+++ b/app/views/pages/homepage/active_homepage.html.erb
@@ -70,7 +70,7 @@
         To earn your Hacktoberfest tee or tree reward, you must register and make four valid pull requests (PRs) between
         October 1-31 (in any time zone). PRs can be made to any public repo on GitHub, not only the ones with issues
         labeled Hacktoberfest. If a maintainer reports your pull request as spam or behavior not in line with the
-        project’s code of conduct, you will be ineligible to participate. This year, the first 75,000 participants who
+        project’s code of conduct, you will be ineligible to participate. This year, the first 70,000 participants who
         successfully complete the challenge will be eligible to receive a prize.
       </p>
       <p>Read the <%= link_to 'participation details', details_path, :class => "participation-link" %> to learn how to

--- a/app/views/pages/homepage/closing_homepage.html.erb
+++ b/app/views/pages/homepage/closing_homepage.html.erb
@@ -70,7 +70,7 @@
         To earn your Hacktoberfest tee or tree reward, you must register and make four valid pull requests (PRs) between
         October 1-31 (in any time zone). PRs can be made to any public repo on GitHub, not only the ones with issues
         labeled Hacktoberfest. If a maintainer reports your pull request as spam or behavior not in line with the
-        project’s code of conduct, you will be ineligible to participate. This year, the first 75,000 participants who
+        project’s code of conduct, you will be ineligible to participate. This year, the first 70,000 participants who
         successfully complete the challenge will be eligible to receive a prize.
       </p>
       <p>Read the <%= link_to 'participation details', details_path, :class => "participation-link" %> to learn how to


### PR DESCRIPTION
# Description
Only the first 70,000 participants will recieve a t-shirt or tree. The site however had 75k in a few places and this was confusing people as evident on Discord. This small PR fixes the text.

# Test process
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

- [ ] Test A
- [ ] Test B

# Requirements to merge
<!--
Ensure your pull request meets all the requirements for merging. Place an `x` in each box to indicate that your pull request meets that requirement.
-->
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
