### PR TITLE
Fix tabs if deep-linked to non-tab anchor

### DIFF
--- a/app/assets/javascripts/tabs.js
+++ b/app/assets/javascripts/tabs.js
@@ -1,14 +1,16 @@
 function showTab(tab, initial) {
-    var $a = $('#' + tab);
-    $('#tabs li a').removeClass('selected');
-    $a.addClass('selected');
-    if (initial || $a.hasClass('inactive')) {
-        $('#tabs li a').addClass('inactive');
-        $a.removeClass('inactive');
-        $('.tab-block').hide();
-        $('#' + tab + '-content').fadeIn('slow');
-        if (!initial) {
-            window.location.hash = '#' + tab;
+    var $a = $('#tabs #' + tab);
+    if ($a.length) {
+        $('#tabs li a').removeClass('selected');
+        $a.addClass('selected');
+        if (initial || $a.hasClass('inactive')) {
+            $('#tabs li a').addClass('inactive');
+            $a.removeClass('inactive');
+            $('.tab-block').hide();
+            $('#' + tab + '-content').fadeIn('slow');
+            if (!initial) {
+                window.location.hash = '#' + tab;
+            }
         }
     }
 }
@@ -18,7 +20,7 @@ $(document).on('turbolinks:load', function() {
     if (initialTab) {
         initialTab = initialTab.slice(1);
     }
-    if (!initialTab) {
+    if (!initialTab || !$('#tabs #' + initialTab).length) {
         initialTab = $('#tabs li a:first').attr('id');
     }
     showTab(initialTab, true);


### PR DESCRIPTION
# Description

If a user deep-linked to an anchor on the page that wasn't a tab, the tabs would all hide themselves. This fixes that.

# Test process

Go to /details#spam, observe tabs are still visible.

Go to /details#companies, observe correct tab is shown.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
