### PR TITLE
Set width percentages on FAQs

### DIFF
--- a/app/assets/stylesheets/faq.scss
+++ b/app/assets/stylesheets/faq.scss
@@ -10,24 +10,15 @@
     display: flex;
     line-height: 130%;
     margin: 0px;
-    max-width: 760px;
-    min-width: 760px;
+    width: 90%;
 
     @media (min-width: 768px) and (max-width: $break-med) {
       font-size: 18px !important;
       margin-right: 35px;
-      min-width: 650px;
-      max-width: 650px;
     }
-
-    @media (max-width: 760px) {
-      min-width: 300px;
-      max-width: 300px;	      
-    }
-
-    @media (min-width: $break-med) {
-      max-width: 900px;
-      min-width: 900px;
+    
+    @media (max-width: $break-mobile) {
+      width: 75%;
     }
     
     &:hover {
@@ -107,6 +98,7 @@
       @extend .answer;
       display: flex;
       flex-flow: wrap;
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
# Description
Set widths as percentages on FAQs to avoid bespoke breakpoints and other pitfalls.

# Test process
FAQs should look right on a variety of mediums (mobile, desktop, etc)

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
