### PR TITLE
Treat PRs labelled with 'spam' as invalid

### DIFF
--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -61,7 +61,7 @@ class PullRequest < ApplicationRecord
   def labelled_invalid?
     return false if merged?
 
-    label_names.select { |l| l[/\binvalid\b/i] }.any?
+    label_names.select { |l| l[/\b(invalid|spam)\b/i] }.any?
   end
 
   def spammy?

--- a/app/views/pages/details.html.erb
+++ b/app/views/pages/details.html.erb
@@ -113,10 +113,10 @@
       </h2>
       <hr/>
       <ul>
-        <li>Spammy pull requests can be labeled as "invalid." Maintainers are faced with the majority of spam that
-          occurs during Hacktoberfest, and we dislike spam just as much as you. If you're a maintainer, please label any
-          spammy pull requests submitted to the repositories you maintain as invalid, and close them. Pull requests with
-          this label won't count toward Hacktoberfest.
+        <li>Spammy pull requests can be given a label that contains the word "invalid" or "spam" to discount them.
+          Maintainers are faced with the majority of spam that occurs during Hacktoberfest, and we dislike spam just as
+          much as you. If you're a maintainer, please label any spammy pull requests submitted to the repositories you
+          maintain as "invalid" or "spam", and close them. Pull requests with this label won't count toward Hacktoberfest.
         </li>
         <li>There's a seven-day review window for all pull requests before they count toward completing the challenge.
           Once a participant has submitted four eligible pull requests (ready-to-review, not drafts), the review window

--- a/app/views/users/show/_timeline.html.erb
+++ b/app/views/users/show/_timeline.html.erb
@@ -63,7 +63,7 @@
             Invalid
           </div>
           <div class="icon-desc">
-            Your PR has been labeled as "invalid" by a maintainer and won't count toward winning Hacktoberfest.
+            Your PR has been labeled as "invalid" or "spam" by a maintainer and won't count toward winning Hacktoberfest.
           </div>
         </div>
       </div>

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PullRequest, type: :model do
       end
 
       context 'Pull request is merged' do
-        let(:pr) { pr_helper(INVALID_LABEL_PR.merge({ 'merged' => true })) }
+        let(:pr) { pr_helper(INVALID_LABEL_PR.merge('merged' => true)) }
 
         it 'is not considered labelled invalid' do
           expect(pr.labelled_invalid?).to eq(false)
@@ -28,7 +28,7 @@ RSpec.describe PullRequest, type: :model do
       end
 
       context 'Pull request is merged' do
-        let(:pr) { pr_helper(INVALID_EMOJI_LABEL_PR.merge({ 'merged' => true })) }
+        let(:pr) { pr_helper(INVALID_EMOJI_LABEL_PR.merge('merged' => true)) }
 
         it 'is not considered labelled invalid' do
           expect(pr.labelled_invalid?).to eq(false)
@@ -44,7 +44,7 @@ RSpec.describe PullRequest, type: :model do
       end
 
       context 'Pull request is merged' do
-        let(:pr) { pr_helper(SPAM_LABEL_PR.merge({ 'merged' => true })) }
+        let(:pr) { pr_helper(SPAM_LABEL_PR.merge('merged' => true)) }
 
         it 'is not considered labelled invalid' do
           expect(pr.labelled_invalid?).to eq(false)
@@ -60,7 +60,7 @@ RSpec.describe PullRequest, type: :model do
       end
 
       context 'Pull request is merged' do
-        let(:pr) { pr_helper(LONG_SPAM_LABEL_PR.merge({ 'merged' => true })) }
+        let(:pr) { pr_helper(LONG_SPAM_LABEL_PR.merge('merged' => true)) }
 
         it 'is not considered labelled invalid' do
           expect(pr.labelled_invalid?).to eq(false)

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PullRequest, type: :model do
       end
 
       context 'Pull request is merged' do
-        let(:pr) { pr_helper(ELIGIBLE_INVALID_MERGED_PR) }
+        let(:pr) { pr_helper(INVALID_LABEL_PR.merge({ 'merged' => true })) }
 
         it 'is not considered labelled invalid' do
           expect(pr.labelled_invalid?).to eq(false)
@@ -23,8 +23,48 @@ RSpec.describe PullRequest, type: :model do
     context 'Pull request has a label for "❌ Invalid"' do
       let(:pr) { pr_helper(INVALID_EMOJI_LABEL_PR) }
 
-      it 'is considered labelled labelled invalid' do
+      it 'is considered labelled invalid' do
         expect(pr.labelled_invalid?).to eq(true)
+      end
+
+      context 'Pull request is merged' do
+        let(:pr) { pr_helper(INVALID_EMOJI_LABEL_PR.merge({ 'merged' => true })) }
+
+        it 'is not considered labelled invalid' do
+          expect(pr.labelled_invalid?).to eq(false)
+        end
+      end
+    end
+
+    context 'Pull request has a label for "Spam"' do
+      let(:pr) { pr_helper(SPAM_LABEL_PR) }
+
+      it 'is considered labelled invalid' do
+        expect(pr.labelled_invalid?).to eq(true)
+      end
+
+      context 'Pull request is merged' do
+        let(:pr) { pr_helper(SPAM_LABEL_PR.merge({ 'merged' => true })) }
+
+        it 'is not considered labelled invalid' do
+          expect(pr.labelled_invalid?).to eq(false)
+        end
+      end
+    end
+
+    context 'Pull request has a label for "This is a spam PR"' do
+      let(:pr) { pr_helper(LONG_SPAM_LABEL_PR) }
+
+      it 'is considered labelled invalid' do
+        expect(pr.labelled_invalid?).to eq(true)
+      end
+
+      context 'Pull request is merged' do
+        let(:pr) { pr_helper(LONG_SPAM_LABEL_PR.merge({ 'merged' => true })) }
+
+        it 'is not considered labelled invalid' do
+          expect(pr.labelled_invalid?).to eq(false)
+        end
       end
     end
 

--- a/spec/support/pull_request_filter_helper.rb
+++ b/spec/support/pull_request_filter_helper.rb
@@ -101,7 +101,7 @@ INVALID_EMOJI_LABEL_PR = {
 }.freeze
 
 INVALID_LABEL_PR = {
-  'id' => 'MDExOlB1bGxSZXF1ZXN0OTA4ODAzMzQ=',
+  'id' => 'MDExOlB1bGxSZXF1ZXN0OTA4ODAzMzQj=',
   'title' => 'Coercion type systems',
   'body' =>
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod

--- a/spec/support/pull_request_filter_helper.rb
+++ b/spec/support/pull_request_filter_helper.rb
@@ -114,6 +114,34 @@ INVALID_LABEL_PR = {
   'repository' => { 'databaseId' => 123 }
 }.freeze
 
+SPAM_LABEL_PR = {
+    'id' => 'MDExOlB1bGxSZXF1ZXN0OTA4ODAzMzQ=',
+    'title' => 'Coercion type systems',
+    'body' =>
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim.',
+    'url' => 'https://github.com/intridea/hashie/pull/379',
+    # This is valid, eligible
+    'createdAt' => (Time.zone.parse(ENV['NOW_DATE']) - 11.days).to_s,
+    # Spam label should make it invalid
+    'labels' => { 'edges' => [{ 'node': { 'name': 'Spam' } }] },
+    'repository' => { 'databaseId' => 123 }
+}.freeze
+
+LONG_SPAM_LABEL_PR = {
+    'id' => 'MDExOlB1bGxSZXF1ZXN0OTA4ODAzMzQ=',
+    'title' => 'Coercion type systems',
+    'body' =>
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim.',
+    'url' => 'https://github.com/intridea/hashie/pull/379',
+    # This is valid, eligible
+    'createdAt' => (Time.zone.parse(ENV['NOW_DATE']) - 11.days).to_s,
+    # Spam label should make it invalid
+    'labels' => { 'edges' => [{ 'node': { 'name': 'This is a spam PR' } }] },
+    'repository' => { 'databaseId' => 123 }
+}.freeze
+
 ELIGIBLE_PR = {
   'id' => 'MDExOlB1bGxSZXF1ZXN0NTE0MTg4ODg=',
   'title' => 'Update README.md',
@@ -124,21 +152,6 @@ ELIGIBLE_PR = {
   # This is valid, eligible
   'createdAt' => (Time.zone.parse(ENV['NOW_DATE']) - 9.days).to_s,
   'labels' => { 'edges' => [] },
-  'repository' => { 'databaseId' => 123 }
-}.freeze
-
-ELIGIBLE_INVALID_MERGED_PR = {
-  'id' => 'MDExOlB1bGxSZXF1ZXN0NjkyNjE4Mjk=',
-  'title' => 'Add natural layer',
-  'body' =>
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-    tempor incididunt ut labore et dolore magna aliqua. Ut enim.',
-  'url' => 'https://github.com/syl20bnr/spacemacs/pull/6012',
-  'createdAt' => (Time.zone.parse(ENV['NOW_DATE']) - 10.days).to_s,
-  # Invalid label should make it invalid
-  'labels' => { 'edges': [{ 'node': { 'name': 'Invalid' } }] },
-  # Merged should override the invalid label and make it valid
-  'merged' => true,
   'repository' => { 'databaseId' => 123 }
 }.freeze
 
@@ -241,7 +254,7 @@ MATURE_ARRAY = [
     'createdAt' => (Time.zone.parse(ENV['NOW_DATE']) - 9.days).to_s,
     'labels' => { 'edges' => [] },
     'repository' => { 'databaseId' => 123 } },
-  ELIGIBLE_INVALID_MERGED_PR,
+  INVALID_LABEL_PR.merge({ 'merged' => true }),
   { 'id' => 'MDExOlB1bGxSZXF1ZXN0OTA4ODAzMzQ=',
     'title' => 'Coercion type systems',
     'body' =>

--- a/spec/support/pull_request_filter_helper.rb
+++ b/spec/support/pull_request_filter_helper.rb
@@ -115,31 +115,31 @@ INVALID_LABEL_PR = {
 }.freeze
 
 SPAM_LABEL_PR = {
-    'id' => 'MDExOlB1bGxSZXF1ZXN0OTA4ODAzMzQ=',
-    'title' => 'Coercion type systems',
-    'body' =>
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-    tempor incididunt ut labore et dolore magna aliqua. Ut enim.',
-    'url' => 'https://github.com/intridea/hashie/pull/379',
-    # This is valid, eligible
-    'createdAt' => (Time.zone.parse(ENV['NOW_DATE']) - 11.days).to_s,
-    # Spam label should make it invalid
-    'labels' => { 'edges' => [{ 'node': { 'name': 'Spam' } }] },
-    'repository' => { 'databaseId' => 123 }
+  'id' => 'MDExOlB1bGxSZXF1ZXN0OTA4ODAzMzQ=',
+  'title' => 'Coercion type systems',
+  'body' =>
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+  tempor incididunt ut labore et dolore magna aliqua. Ut enim.',
+  'url' => 'https://github.com/intridea/hashie/pull/379',
+  # This is valid, eligible
+  'createdAt' => (Time.zone.parse(ENV['NOW_DATE']) - 11.days).to_s,
+  # Spam label should make it invalid
+  'labels' => { 'edges' => [{ 'node': { 'name': 'Spam' } }] },
+  'repository' => { 'databaseId' => 123 }
 }.freeze
 
 LONG_SPAM_LABEL_PR = {
-    'id' => 'MDExOlB1bGxSZXF1ZXN0OTA4ODAzMzQ=',
-    'title' => 'Coercion type systems',
-    'body' =>
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-    tempor incididunt ut labore et dolore magna aliqua. Ut enim.',
-    'url' => 'https://github.com/intridea/hashie/pull/379',
-    # This is valid, eligible
-    'createdAt' => (Time.zone.parse(ENV['NOW_DATE']) - 11.days).to_s,
-    # Spam label should make it invalid
-    'labels' => { 'edges' => [{ 'node': { 'name': 'This is a spam PR' } }] },
-    'repository' => { 'databaseId' => 123 }
+  'id' => 'MDExOlB1bGxSZXF1ZXN0OTA4ODAzMzQ=',
+  'title' => 'Coercion type systems',
+  'body' =>
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+  tempor incididunt ut labore et dolore magna aliqua. Ut enim.',
+  'url' => 'https://github.com/intridea/hashie/pull/379',
+  # This is valid, eligible
+  'createdAt' => (Time.zone.parse(ENV['NOW_DATE']) - 11.days).to_s,
+  # Spam label should make it invalid
+  'labels' => { 'edges' => [{ 'node': { 'name': 'This is a spam PR' } }] },
+  'repository' => { 'databaseId' => 123 }
 }.freeze
 
 ELIGIBLE_PR = {
@@ -254,7 +254,7 @@ MATURE_ARRAY = [
     'createdAt' => (Time.zone.parse(ENV['NOW_DATE']) - 9.days).to_s,
     'labels' => { 'edges' => [] },
     'repository' => { 'databaseId' => 123 } },
-  INVALID_LABEL_PR.merge({ 'merged' => true }),
+  INVALID_LABEL_PR.merge('merged' => true),
   { 'id' => 'MDExOlB1bGxSZXF1ZXN0OTA4ODAzMzQ=',
     'title' => 'Coercion type systems',
     'body' =>


### PR DESCRIPTION
# Description

Not only should we treat PRs labelled as "invalid" as invalid, we should also treat those labelled as "spam" as invalid.

# Test process

See spec.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
