### PR TITLE
Fix overflowing button on mobile

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -366,6 +366,11 @@ body {
     font-family: "Inter Black", "Helvetica", "Arial", san-serif;
   }
 
+  .button {
+    white-space: normal;
+    max-width: 100%;
+  }
+
   // -------- Global light mode styles --------
   background-color: $light-backgroundColor;
   color: $light-textColor;


### PR DESCRIPTION
# Description

Fix browse on github button that was overflowing on mobile. DODX 1523.

![image](https://user-images.githubusercontent.com/12371363/94476335-3e957000-01c8-11eb-8f14-fc20b3c9d363.png)


# Test process

Button no longer overflows on mobile, text inside wraps.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
