### PR TITLE
Only start the timer for a PR if it's waiting

### DIFF
--- a/app/views/users/show/pr/_pr.html.erb
+++ b/app/views/users/show/pr/_pr.html.erb
@@ -21,9 +21,11 @@
   </td>
 </tr>
 
-<script type="text/javascript">
-    countdownTimers(
-        document.getElementById('<%= pr.github_id %>-waiting-date'),
-        "<%= pr.waiting_since&.httpdate %>",
-    );
-</script>
+<% if pr.waiting? %>
+  <script type="text/javascript">
+      countdownTimers(
+          document.getElementById('<%= pr.github_id %>-waiting-date'),
+          "<%= pr.waiting_since&.httpdate %>",
+      );
+  </script>
+<% end %>


### PR DESCRIPTION
# Description

We were seeing a lot of `TypeError:  Cannot set property 'innerHTML' of null` in Airbrake (47k occurrences as of writing this). This was coming from the fact that we were starting the timer, which then ran every 1s whilst the profile was open, for all PRs irrespective of if they actually needed the timer or not.

# Test process

Have a PR on your profile that is valid, or spammy, and observe that there is no error in console.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
