### PR TITLE
Remove default opt-in for marketing emails

### DIFF
--- a/app/views/users/registration.html.erb
+++ b/app/views/users/registration.html.erb
@@ -16,7 +16,7 @@
             <div class="field">
               <div class="control">
                 <label class="checkbox">
-                  <%= f.check_box :digitalocean_marketing_emails, { checked: true }, :class => 'check-style' %>
+                  <%= f.check_box :digitalocean_marketing_emails, :class => 'check-style' %>
                   Send me updates related to the Hacktoberfest community,
                   open source, and products from DigitalOcean.
                 </label>


### PR DESCRIPTION
# Description

We were opting folks into DigitalOcean marketing by default, which our community did not agree with as it is a dark pattern. This makes the checkbox unchecked by default.

# Test process

Register, no checkboxes are checked by default.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
