### PR TITLE
Add rescue behavior for MLH API

### DIFF
--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -8,7 +8,7 @@ module PagesHelper
       # Ignore invalid events
     end.compact
   rescue JSON::ParserError
-    AirtablePlaceholderService.call('Event List').map do |e|
+    AirtablePlaceholderService.call('Meetups').map do |e|
       MlhEventPresenter.new(e)
     end.compact
   end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -7,6 +7,10 @@ module PagesHelper
     rescue MlhEventPresenter::ParseError
       # Ignore invalid events
     end.compact
+  rescue JSON::ParserError
+    AirtablePlaceholderService.call('Event List').map do |e|
+      MlhEventPresenter.new(e)
+    end.compact
   end
 
   def front_page_events

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -11,6 +11,10 @@ module PagesHelper
     AirtablePlaceholderService.call('Meetups').map do |e|
       MlhEventPresenter.new(e)
     end.compact
+  rescue StandardError
+    AirtablePlaceholderService.call('Meetups').map do |e|
+      MlhEventPresenter.new(e)
+    end.compact
   end
 
   def front_page_events

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -7,10 +7,6 @@ module PagesHelper
     rescue MlhEventPresenter::ParseError
       # Ignore invalid events
     end.compact
-  rescue JSON::ParserError
-    AirtablePlaceholderService.call('Meetups').map do |e|
-      MlhEventPresenter.new(e)
-    end.compact
   rescue StandardError
     AirtablePlaceholderService.call('Meetups').map do |e|
       MlhEventPresenter.new(e)

--- a/app/services/airtable_placeholder_service.rb
+++ b/app/services/airtable_placeholder_service.rb
@@ -42,32 +42,64 @@ module AirtablePlaceholderService
     when 'Event List'
       [
         {
-          'Event Named' => 'Hacktoberfest 2020 Official Kick-Off Celebration',
-          'Event City' => 'APAC',
-          'Event Country' => 'India',
-          'Date' => '2020-10-01',
-          'Link' => 'https://organize.mlh.io/participants/events/4019-hacktoberfest-2020-official-kick-off-celebration'
+          'attributes' => {
+            'title' => 'Hacktoberfest in Brasilia',
+            'startDate' => '2020-10-16',
+            'timeZone' => 'America/Sao_Paulo',
+            'location' => {
+              'city' => 'Brasilia',
+              'country' => 'Brazil'
+            }
+          },
+          'links' => {
+            'register' => 'http://organize.mlh.io/participants/events/3921-hacktoberfest-in-brasilia/register',
+            'view' => 'http://organize.mlh.io/participants/events/3921-hacktoberfest-in-brasilia'
+          }
         },
         {
-          'Event Named' => 'Hacktoberfest Tuesdays: Americas',
-          'Event City' => 'New York',
-          'Event Country' => 'United States',
-          'Date' => '2020-10-06',
-          'Link' => 'https://organize.mlh.io/participants/events/4079-hacktoberfest-tuesdays-east-coast-and-more'
+          'attributes' => {
+            'title' => 'Hacktoberfest 2020 Official Kick-Off Celebration',
+            'startDate' => '2020-10-01',
+            'timeZone' => 'Asia/Calcutta',
+            'location' => {
+              'city' => 'APAC',
+              'country' => 'India'
+            }
+          },
+          'links' => {
+            'register' => 'https://organize.mlh.io/participants/events/4019-hacktoberfest-2020-official-kick-off-celebration/register',
+            'view' => 'https://organize.mlh.io/participants/events/4019-hacktoberfest-2020-official-kick-off-celebration'
+          }
         },
         {
-          'Event Named' => 'Hacktoberfest Tuesdays: Asia',
-          'Event City' => 'Singapore',
-          'Event Country' => 'Singapore',
-          'Date' => '2020-10-13',
-          'Link' => 'https://organize.mlh.io/participants/events/4099-hacktoberfest-tuesdays-asia'
+          'attributes' => {
+            'title' => 'Hacktoberfest Tuesdays: Europe',
+            'startDate' => '2020-10-27',
+            'timeZone' => 'Europe/London',
+            'location' => {
+              'city' => 'London',
+              'country' => 'United Kingdom'
+            }
+          },
+          'links' => {
+            'register' => 'https://organize.mlh.io/participants/events/4101-hacktoberfest-tuesdays-europe/register',
+            'view' => 'https://organize.mlh.io/participants/events/4101-hacktoberfest-tuesdays-europe'
+          }
         },
         {
-          'Event Named' => 'Hacktoberfest Tuesdays: Europe',
-          'Event City' => 'London',
-          'Event Country' => 'United Kingdom',
-          'Date' => '2020-10-27',
-          'Link' => 'https://organize.mlh.io/participants/events/4101-hacktoberfest-tuesdays-europe'
+          'attributes' => {
+            'title' => 'Hacktoberfest Tuesdays: Americas',
+            'startDate' => '2020-10-06',
+            'timeZone' => 'America/New_York',
+            'location' => {
+              'city' => 'New York',
+              'country' => 'United States'
+            }
+          },
+          'links' => {
+            'register' => 'https://organize.mlh.io/participants/events/4079-hacktoberfest-tuesdays-east-coast-and-more/register',
+            'view' => 'https://organize.mlh.io/participants/events/4079-hacktoberfest-tuesdays-east-coast-and-more'
+          }
         }
       ]
     when 'FAQs'

--- a/app/services/airtable_placeholder_service.rb
+++ b/app/services/airtable_placeholder_service.rb
@@ -8,38 +8,6 @@ module AirtablePlaceholderService
   def call(table_name)
     case table_name
     when 'Meetups'
-      {
-        'data' =>
-        [
-          {
-            'attributes' => {
-              'title' => 'Hacktoberfest in Brasilia',
-              'startDate' => '2020-10-16',
-              'location' => {
-                'city' => 'Brasilia',
-                'country' => 'Brazil'
-              }
-            },
-            'links' => {
-              'register' => 'http://organize.mlh.io/participants/events/3921-hacktoberfest-in-brasilia/register'
-            }
-          },
-          {
-            'attributes' => {
-              'title' => 'Hacktoberfest @IPN',
-              'startDate' => '2020-10-01',
-              'location' => {
-                'city' => 'Mexico City',
-                'country' => 'Mexico'
-              }
-            },
-            'links' => {
-              'register' => 'http://organize.mlh.io/participants/events/3924-hacktoberfest-ipn/register'
-            }
-          }
-        ]
-      }
-    when 'Event List'
       [
         {
           'attributes' => {
@@ -100,6 +68,37 @@ module AirtablePlaceholderService
             'register' => 'https://organize.mlh.io/participants/events/4079-hacktoberfest-tuesdays-east-coast-and-more/register',
             'view' => 'https://organize.mlh.io/participants/events/4079-hacktoberfest-tuesdays-east-coast-and-more'
           }
+        }
+      ]
+    when 'Event List'
+      [
+        {
+          'Event Named' => 'Hacktoberfest 2020 Official Kick-Off Celebration',
+          'Event City' => 'APAC',
+          'Event Country' => 'India',
+          'Date' => '2020-10-01',
+          'Link' => 'https://organize.mlh.io/participants/events/4019-hacktoberfest-2020-official-kick-off-celebration'
+        },
+        {
+          'Event Named' => 'Hacktoberfest Tuesdays: Americas',
+          'Event City' => 'New York',
+          'Event Country' => 'United States',
+          'Date' => '2020-10-06',
+          'Link' => 'https://organize.mlh.io/participants/events/4079-hacktoberfest-tuesdays-east-coast-and-more'
+        },
+        {
+          'Event Named' => 'Hacktoberfest Tuesdays: Asia',
+          'Event City' => 'Singapore',
+          'Event Country' => 'Singapore',
+          'Date' => '2020-10-13',
+          'Link' => 'https://organize.mlh.io/participants/events/4099-hacktoberfest-tuesdays-asia'
+        },
+        {
+          'Event Named' => 'Hacktoberfest Tuesdays: Europe',
+          'Event City' => 'London',
+          'Event Country' => 'United Kingdom',
+          'Date' => '2020-10-27',
+          'Link' => 'https://organize.mlh.io/participants/events/4101-hacktoberfest-tuesdays-europe'
         }
       ]
     when 'FAQs'

--- a/app/services/mlh_table.rb
+++ b/app/services/mlh_table.rb
@@ -28,11 +28,9 @@ class MlhTable
         )
       end
     end
-    if response.success?
-      response.body
-    else
-      AirtablePlaceholderService.call('Meetups')
-    end
+    response.body if response.success?
+  rescue StandardError
+    { 'data' => AirtablePlaceholderService.call('Meetups') }
   end
 
   def records

--- a/app/services/mlh_table.rb
+++ b/app/services/mlh_table.rb
@@ -29,7 +29,6 @@ class MlhTable
       end
     end
     response.body if response.success?
-  rescue StandardError
     { 'data' => AirtablePlaceholderService.call('Meetups') }
   end
 

--- a/app/services/mlh_table.rb
+++ b/app/services/mlh_table.rb
@@ -28,7 +28,8 @@ class MlhTable
         )
       end
     end
-    response.body if response.success?
+    return response.body if response.success?
+
     { 'data' => AirtablePlaceholderService.call('Meetups') }
   end
 

--- a/spec/services/mlh_table_service_spec.rb
+++ b/spec/services/mlh_table_service_spec.rb
@@ -38,7 +38,7 @@ describe MlhTable do
 
     it 'creates a mock table object' do
       table = AirtablePlaceholderService.call('Meetups')
-      expect(table).to have_key('data')
+      expect(table.first).to have_key('attributes')
     end
   end
   # rubocop:enable Metrics/LineLength


### PR DESCRIPTION
# Description
In cases where we are not getting information returned from MLH, show dummy data instead.

# Test process
Set `faraday_connection` to return an empty string, and test that data shows correctly on events page.

# Requirements to merge
<!--
Ensure your pull request meets all the requirements for merging. Place an `x` in each box to indicate that your pull request meets that requirement.
-->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
