### PR TITLE
Update Helpdesk links and CTA on users#show

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,7 +25,7 @@
           </div>
         <% end %>
       </div>
-      
+
       <% if @presenter.display_pre_launch? %>
         <div class="container pre-launch-container">
           <h2 class='title is-2'>Get ready to start contributing to Hacktoberfest.</h2>
@@ -87,6 +87,7 @@
           <li><a href="https://hacktoberfest.digitalocean.com/details/" target="_blank">Digest the Resources</a></li>
           <li><a href="https://hacktoberfest.digitalocean.com/faq/" target="_blank">Get Answers Before Asking</a></li>
           <li><a href="https://www.digitalocean.com/community/tutorials/how-to-maintain-open-source-software-projects" target="_blank">Learn About Maintainer Experience</a></li>
+          <li><a href="https://raise.dev/hacktoberfest" target="_blank">Get help from the Helpdesk</a></li>
         </ul>
       </div>
       <div class="education-section">
@@ -95,11 +96,11 @@
           <li><a href="https://hacktoberfest.digitalocean.com/eventkit/" target="_blank">Organize a Hacktoberfest Meetup</a></li>
           <li><a href="https://www.digitalocean.com/community/meetup_kits/hacktoberfest-workshop-kit-how-to-submit-your-first-pull-request-on-github" target="_blank">Lead an Open Source Workshop</a></li>
           <li><a href="https://dev.to/" target="_blank">Share Your Experience on DEV</a></li>
-          <li><a href="https://raise.dev/hacktoberfest" target="_blank">Apply to Become a Coach</a></li>
+          <li><a href="https://raise.dev/hacktoberfest" target="_blank">Answer questions on the Helpdesk</a></li>
         </ul>
       </div>
     </div>
-    
+
   </div>
 
 </div>


### PR DESCRIPTION
# Description
I just signed up to participate in Hacktoberfest and noticed that the CTA for the Helpdesk was "Become a Coach". This modifies the CTA to "Answer questions on the Helpdesk" and also adds a CTA "Get help from the Helpdesk" in the "EDUCATION HUB" section:

<img width="354" alt="Screen Shot 2020-09-30 at 7 02 44 PM" src="https://user-images.githubusercontent.com/123345/94748532-87c3fc00-034f-11eb-8fed-8a71b8dc2918.png">


# Requirements to merge
<!--
Ensure your pull request meets all the requirements for merging. Place an `x` in each box to indicate that your pull request meets that requirement.
-->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ n/a
- [x] New and existing unit tests pass locally with my changes
