### PR TITLE
Add more prominent registration guidance

### DIFF
--- a/app/assets/javascripts/registration.js
+++ b/app/assets/javascripts/registration.js
@@ -12,7 +12,7 @@ window.addEventListener("click", (e) => {
         $form_second.toggleClass('hidden');
     }
 
-    $video.bind("end", function(t) {
+    $video.bind("end", function() {
         //logic here
     });
 

--- a/app/assets/javascripts/registration.js
+++ b/app/assets/javascripts/registration.js
@@ -2,7 +2,8 @@ window.addEventListener("click", (e) => {
     $target = $(e.target),
     $form_first = $('#form-first'),
     $form_second = $('#form-second'),
-    $video = Wistia.api('u8up7h2m32');
+    $video = Wistia.api('u8up7h2m32'),
+    $quality_checkers = $('.check-extra')
 
     if ($target.attr('data-js') === "continue" ) {
         $form_first.toggleClass('hidden');
@@ -13,7 +14,9 @@ window.addEventListener("click", (e) => {
     }
 
     $video.bind("end", function() {
-        //logic here
+        $quality_checkers.each(function() {
+            $(this).removeAttr('disabled');     
+        });
     });
 
 });

--- a/app/assets/javascripts/registration.js
+++ b/app/assets/javascripts/registration.js
@@ -1,7 +1,8 @@
 window.addEventListener("click", (e) => {
     $target = $(e.target),
     $form_first = $('#form-first'),
-    $form_second = $('#form-second');
+    $form_second = $('#form-second'),
+    $video = Wistia.api('u8up7h2m32');
 
     if ($target.attr('data-js') === "continue" ) {
         $form_first.toggleClass('hidden');
@@ -10,4 +11,9 @@ window.addEventListener("click", (e) => {
         $form_first.toggleClass('hidden');
         $form_second.toggleClass('hidden');
     }
+
+    $video.bind("end", function(t) {
+        //logic here
+    });
+
 });

--- a/app/assets/javascripts/registration.js
+++ b/app/assets/javascripts/registration.js
@@ -1,0 +1,13 @@
+window.addEventListener("click", (e) => {
+    $target = $(e.target),
+    $form_first = $('#form-first'),
+    $form_second = $('#form-second');
+
+    if ($target.attr('data-js') === "continue" ) {
+        $form_first.toggleClass('hidden');
+        $form_second.toggleClass('hidden');
+    } else if ($target.attr('data-js') === "back") {
+        $form_first.toggleClass('hidden');
+        $form_second.toggleClass('hidden');
+    }
+});

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -595,6 +595,29 @@ body {
       }
     }
   }
+
+  //info callouts
+
+  .info-pane {
+    background: rgba($grey, .1);
+    border-radius: 0.5rem;
+    padding: 1rem;
+
+    .info-pane-item {
+      padding: 1rem;
+      margin: 1rem 0;
+
+      &.do {
+        border-left: .25rem solid $success;
+        background: rgba($success, 0.1);
+      }
+      &.dont {
+        border-left: .25rem solid $danger;
+        background: rgba($danger, 0.1);
+      }
+    }
+  }
+  
   //social share
   .social {
     .social-wrapper {

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -54,6 +54,9 @@ $cyan: hsl(191.56, 100%, 78.63%);
 $purple: hsl(286.79, 73.68%, 44.71%);
 $yellow: hsl(58.37, 100%, 56.67%);
 
+$danger: #e74c3c;
+$success: #2ecc71;
+
 $size-1: 2.25rem;
 $size-2: 2rem;
 $size-3: 1.5rem;

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -232,6 +232,47 @@
       }
     }
 
+    .idea-set {
+      display: flex;
+      flex-wrap: wrap;
+      padding-top: 1rem;
+
+      .idea-pane {
+        background: rgba($cyan, 0.1);
+        padding: 2rem 1rem;
+        margin: 1rem;
+        position: relative;
+        width: calc(50% - 2rem);
+        min-width: 300px;
+        
+        &[data-label]:before {
+          content: attr(data-label);
+          display: inline-block;
+          position: absolute;
+          top: -2rem;
+          left: -1rem;
+          background: $pink;
+          box-shadow: $box-shadow;
+          color: $black;
+          width: 130px;
+          padding: 0.2rem;
+          transform: rotate(-15deg);
+          border-radius: .5rem;
+        }
+
+        p {
+          font-size: 1rem;
+          margin-bottom: calc(1rem + 49px);
+        }
+
+        .button-static {
+          position: absolute;
+          bottom: 1.5rem;
+          right: 1.5rem;
+        }
+      }
+    }
+
     .timeline-wrapper {
       width: 100%;
       display: flex;

--- a/app/assets/stylesheets/register.scss
+++ b/app/assets/stylesheets/register.scss
@@ -16,6 +16,14 @@ section.reg-content {
       width: 50%;
       margin-right: 4%;
 
+      form {
+        display: flex;
+      }
+
+      .hidden {
+        display: none;
+      }
+
       .register-header {
         color: $dark-textColor;
         font-family: $family-sans-serif;
@@ -69,7 +77,8 @@ section.reg-content {
         height: 15px;
       }
 
-      .submit-btn {
+      .submit-btn,
+      .btn-sml {
         display: flex;
         flex-direction: row;
         padding: 21px 40px;
@@ -87,6 +96,14 @@ section.reg-content {
         &:hover {
           background-color: $pink;
         }
+      }
+
+      .btn-sml {
+        width: 27%;
+      }
+
+      .btn-back {
+        padding-left: 70px;
       }
     }
 

--- a/app/assets/stylesheets/register.scss
+++ b/app/assets/stylesheets/register.scss
@@ -99,11 +99,14 @@ section.reg-content {
       }
 
       .btn-sml {
+        text-align: center;
         width: 27%;
       }
 
       .btn-back {
         padding-left: 70px;
+        text-align: center;
+        width: 35%;
       }
     }
 

--- a/app/assets/stylesheets/register.scss
+++ b/app/assets/stylesheets/register.scss
@@ -109,6 +109,27 @@ section.reg-content {
         max-width: 570px;
         height: 100%;
       }
+
+      .info-pane {
+        background: rgba($grey, .1);
+        border-radius: 0.5rem;
+        padding: 1rem;
+
+        .info-pane-item {
+          padding: 1rem;
+          margin: 1rem 0;
+
+          &.do {
+            border-left: .25rem solid $success;
+            background: rgba($success, 0.1);
+          }
+          &.dont {
+            border-left: .25rem solid $danger;
+            background: rgba($danger, 0.1);
+          }
+        }
+
+      }
     }
   }
 }

--- a/app/assets/stylesheets/register.scss
+++ b/app/assets/stylesheets/register.scss
@@ -72,13 +72,13 @@ section.reg-content {
         color: $light-categoryColor;
       }
 
-      .check-style {
+      .check-style,
+      .check-extra {
         width: 15px;
         height: 15px;
       }
 
-      .submit-btn,
-      .btn-sml {
+      .submit-btn {
         display: flex;
         flex-direction: row;
         padding: 21px 40px;
@@ -96,17 +96,36 @@ section.reg-content {
         &:hover {
           background-color: $pink;
         }
+
+        @media screen and (max-width: $break-mobile) {
+          display: inline-flex;
+        }
       }
 
       .btn-sml {
+        align-items: flex-start;
+        background-color: $blue;
+        border-color: $blue;
+        border-width: 0;
+        box-shadow: 0px 20px 20px rgba(0, 0, 0, 0.05);
+        color: $buttonTextColor;
+        cursor: pointer;
+        display: inline-flex;
+        font-weight: 900;
+        font-size: $size-button-text;
+        justify-content: center;
+        padding: 20px 75px;
         text-align: center;
-        width: 27%;
-      }
+        text-transform: uppercase;
+        white-space: nowrap;
+        -moz-border-radius: 30px;
+        -webkit-border-radius: 30px;
+        -khtml-border-radius: 30px;
+        border-radius: 30px;
 
-      .btn-back {
-        padding-left: 70px;
-        text-align: center;
-        width: 35%;
+        &:hover {
+          background-color: $pink;
+        } 
       }
     }
 
@@ -128,27 +147,6 @@ section.reg-content {
         width: 100%;
         max-width: 570px;
         height: 100%;
-      }
-
-      .info-pane {
-        background: rgba($grey, .1);
-        border-radius: 0.5rem;
-        padding: 1rem;
-
-        .info-pane-item {
-          padding: 1rem;
-          margin: 1rem 0;
-
-          &.do {
-            border-left: .25rem solid $success;
-            background: rgba($success, 0.1);
-          }
-          &.dont {
-            border-left: .25rem solid $danger;
-            background: rgba($danger, 0.1);
-          }
-        }
-
       }
     }
   }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -77,7 +77,9 @@ class UsersController < ApplicationController
       :intel_marketing_emails,
       :dev_marketing_emails,
       :category,
-      :country
+      :country,
+      :quality_acceptance,
+      :disqualify_acceptance
     )
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,8 @@ class User < ApplicationRecord
     state all - [:new] do
       validates :terms_acceptance, acceptance: true
       validates :email, presence: true
+      validates :quality_acceptance, acceptance: true
+      validates :disqualify_acceptance, acceptance: true
     end
 
     state all - [:won_shirt] do

--- a/app/views/users/registration.html.erb
+++ b/app/views/users/registration.html.erb
@@ -114,7 +114,7 @@
         <h3>Do's and Dont's of Hacktoberfest</h3>
         <div class="info-pane-item dont">
           <h2>Don't: open pull requests with minor text edits on other people's repositories</h2>
-          <p>If you're looking for a faster way to open four PR's and win, <a href="#">there's a better way!</a></p>
+          <p>If you're looking for a faster way to open four PR's and win, there's a better way!</p>
         </div>
         <div class="info-pane-item do">
           <h2>Do: Follow a repository's contribution guidelines</h2>
@@ -122,7 +122,7 @@
         </div>
         <div class="info-pane-item dont">
           <h2>Don't: feel intimidated</h2>
-          <p><a href="#">Register for an event</a> and learn with a group, or connect with others in the Discord chat.</p>
+          <p><a href="/events">Register for an event</a> and learn with a group, or connect with others in the Discord chat.</p>
         </div>
       </div>
     </div>  

--- a/app/views/users/registration.html.erb
+++ b/app/views/users/registration.html.erb
@@ -1,67 +1,81 @@
 <section class="section reg-content">
   <div class="container">
     <div class="registration-wrapper">
-      <div class="registration-left">
-        <div class="register-header">Register</div>
-        <h1 class="title is-1">About you</h1>
-        <p>
-          Please select which email address you’d like to use for Hacktoberfest and read the
-          <a target="_blank" href="/details#rules">rules and values</a>.
-        </p>
+        <div class="registration-left">
+          <div class="register-header">Register</div>
+          <h1 class="title is-1">About you</h1>
+          <p>
+            Please select which email address you’d like to use for Hacktoberfest and read the
+            <a target="_blank" href="/details#rules">rules and values</a>.
+          </p>
 
-        <%= form_for :user, url: {action: 'register'}, method: :patch do |f| %>
-          <%= render partial: 'users/dropdowns', locals: { f: f, u: User.new } %>
+          <%= form_for :user, url: {action: 'register'}, method: :patch do |f| %>
+            <%= render partial: 'users/dropdowns', locals: { f: f, u: User.new } %>
 
-          <div class="checkboxes">
+            <div class="checkboxes">
+              <div class="field">
+                <div class="control">
+                  <label class="checkbox">
+                    <%= f.check_box :digitalocean_marketing_emails, :class => 'check-style' %>
+                    Send me updates related to the Hacktoberfest community,
+                    open source, and products from DigitalOcean.
+                  </label>
+                </div>
+              </div>
+
+              <div class="field">
+                <div class="control">
+                  <label class="checkbox">
+                    <%= f.check_box :intel_marketing_emails, :class => 'check-style' %>
+                    Send me updates related to the Intel community and products.
+                  </label>
+                </div>
+              </div>
+
+              <div class="field">
+                <div class="control">
+                  <label class="checkbox">
+                    <%= f.check_box :dev_marketing_emails, :class => 'check-style' %>
+                    Send me updates related to the DEV community and products.
+                  </label>
+                </div>
+              </div>
+            </div>
+
+            <% if @current_user.errors.messages[:terms_acceptance].include?("must be accepted") %>
+              <p class="error">You must accept the terms and conditions to participate in Hactoberfest.</p>
+            <% end %>
+
             <div class="field">
               <div class="control">
                 <label class="checkbox">
-                  <%= f.check_box :digitalocean_marketing_emails, :class => 'check-style' %>
-                  Send me updates related to the Hacktoberfest community,
-                  open source, and products from DigitalOcean.
+                  <%= f.check_box :terms_acceptance, {:class => 'check-style', :required => true} %>
+                  I have read and understand the
+                  <a target="_blank" href="/details#rules">Rules and Values</a>.
                 </label>
               </div>
             </div>
 
-            <div class="field">
-              <div class="control">
-                <label class="checkbox">
-                  <%= f.check_box :intel_marketing_emails, :class => 'check-style' %>
-                  Send me updates related to the Intel community and products.
-                </label>
-              </div>
-            </div>
-
-            <div class="field">
-              <div class="control">
-                <label class="checkbox">
-                  <%= f.check_box :dev_marketing_emails, :class => 'check-style' %>
-                  Send me updates related to the DEV community and products.
-                </label>
-              </div>
-            </div>
-          </div>
-
-          <% if @current_user.errors.messages[:terms_acceptance].include?("must be accepted") %>
-            <p class="error">You must accept the terms and conditions to participate in Hactoberfest.</p>
+            <%= f.submit 'Start Hacking', :class => 'submit-btn' %>
           <% end %>
-
-          <div class="field">
-            <div class="control">
-              <label class="checkbox">
-                <%= f.check_box :terms_acceptance, {:class => 'check-style', :required => true} %>
-                I have read and understand the
-                <a target="_blank" href="/details#rules">Rules and Values</a>.
-              </label>
-            </div>
-          </div>
-
-          <%= f.submit 'Start Hacking', :class => 'submit-btn' %>
-        <% end %>
-      </div>
+        </div>
 
       <div class="registration-right">
-        <div class="background-img"></div>
+        <div class="info-pane">
+          <h3>Do's and Dont's of Hacktoberfest</h3>
+          <div class="info-pane-item dont">
+            <h2>Don't: open PR's with tiny text edits on other people's repositories</h2>
+            <p>If you're looking for a fast way to open four PR's and win, <a href="#">there's a better way!</a></p>
+          </div>
+          <div class="info-pane-item do">
+            <h2>Do: Follow a repo's contribution guidelines</h2>
+            <p>Almost every repo looking for help has a <code>CONTRIBUTING.md</code> file in it, <em>read it first!</em></p>
+          </div>
+          <div class="info-pane-item dont">
+            <h2>Don't: feel intimidated</h2>
+            <p><a href="#">Register for an event</a> and learn with a group, or <a href="#">join the discord chat</a> to connect with others.</p>
+          </div>
+        </section>
       </div>
     </div>
   </div>

--- a/app/views/users/registration.html.erb
+++ b/app/views/users/registration.html.erb
@@ -46,6 +46,12 @@
             <% if @current_user.errors.messages[:terms_acceptance].include?("must be accepted") %>
               <p class="error">You must accept the terms and conditions to participate in Hactoberfest.</p>
             <% end %>
+            <% if @current_user.errors.messages[:quality_acceptance].include?("must be accepted") %>
+              <p class="error">You must acknowledge what constitues a quality contribution to participate in Hactoberfest.</p>
+            <% end %>
+            <% if @current_user.errors.messages[:disqualify_acceptance].include?("must be accepted") %>
+              <p class="error">You must acknowledge that you will be disqualified for submitting two invalid pull requests.</p>
+            <% end %>
 
             <div class="field">
               <div class="control">
@@ -56,11 +62,12 @@
                 </label>
               </div>
             </div>
-            <div data-js="continue" class="submit-btn btn-sml">Continue</div>
+            <div data-js="continue" class="btn-sml">Continue</div>
           </div>
 
           <div id="form-second" class="hidden">
             <p>Before you get started, learn how to create a quality pull request:</p>
+            <br>
             <div class="beginners-video">
               <script src="https://fast.wistia.com/embed/medias/u8up7h2m32.jsonp" async></script>
               <script src="https://fast.wistia.com/assets/external/E-v1.js" async></script>
@@ -75,8 +82,29 @@
               </div>
             </div>
 
+            <br>
+            <div class="field">
+              <div class="control">
+                <label class="checkbox">
+                  <%= f.check_box :quality_acceptance, {:class => 'check-extra', :disabled => 'disable'} %>
+                  I have acknowledged these resources and 
+                  understand what a quality contribution is to open source.
+                </label>
+              </div>
+            </div>
+
+            <div class="field">
+              <div class="control">
+                <label class="checkbox">
+                  <%= f.check_box :disqualify_acceptance, {:class => 'check-extra', :disabled => 'disable'} %>
+                  I acknowledge that I will be disqualified indefinitely from Hacktoberfest 
+                  if I submit two invalid pull requests.
+                </label>
+              </div>
+            </div>
+
             <%= f.submit 'Start Hacking', :class => 'submit-btn' %>
-            <div data-js="back" class="submit-btn btn-back">Back</div>
+            <div data-js="back" class="btn-sml">Back</div>
           </end>
         <% end %>
       </div>
@@ -85,16 +113,16 @@
       <div class="info-pane">
         <h3>Do's and Dont's of Hacktoberfest</h3>
         <div class="info-pane-item dont">
-          <h2>Don't: open PR's with tiny text edits on other people's repositories</h2>
-          <p>If you're looking for a fast way to open four PR's and win, <a href="#">there's a better way!</a></p>
+          <h2>Don't: open pull requests with minor text edits on other people's repositories</h2>
+          <p>If you're looking for a faster way to open four PR's and win, <a href="#">there's a better way!</a></p>
         </div>
         <div class="info-pane-item do">
-          <h2>Do: Follow a repo's contribution guidelines</h2>
+          <h2>Do: Follow a repository's contribution guidelines</h2>
           <p>Almost every repo looking for help has a <code>CONTRIBUTING.md</code> file in it, <em>read it first!</em></p>
         </div>
         <div class="info-pane-item dont">
           <h2>Don't: feel intimidated</h2>
-          <p><a href="#">Register for an event</a> and learn with a group, or <a href="#">join the discord chat</a> to connect with others.</p>
+          <p><a href="#">Register for an event</a> and learn with a group, or connect with others in the Discord chat.</p>
         </div>
       </div>
     </div>  

--- a/app/views/users/registration.html.erb
+++ b/app/views/users/registration.html.erb
@@ -3,14 +3,14 @@
     <div class="registration-wrapper">
       <div class="registration-left">
         <div class="register-header">Register</div>
-        <h1 class="title is-1">About you</h1>
-        <p>
-          Please select which email address you’d like to use for Hacktoberfest and read the
-          <a target="_blank" href="/details#rules">rules and values</a>.
-        </p>
 
         <%= form_for :user, url: {action: 'register'}, method: :patch do |f| %>
           <div id="form-first">
+            <h1 class="title is-1">About you</h1>
+            <p>
+              Please select which email address you’d like to use for Hacktoberfest and read the
+              <a target="_blank" href="/details#rules">rules and values</a>.
+            </p>
             <%= render partial: 'users/dropdowns', locals: { f: f, u: User.new } %>
 
             <div class="checkboxes">
@@ -60,8 +60,22 @@
           </div>
 
           <div id="form-second" class="hidden">
+            <p>Before you get started, learn how to create a quality pull request:</p>
+            <div class="beginners-video">
+              <script src="https://fast.wistia.com/embed/medias/u8up7h2m32.jsonp" async></script>
+              <script src="https://fast.wistia.com/assets/external/E-v1.js" async></script>
+              <div class="wistia_responsive_padding" style="padding:56.25% 0 0 0;position:relative;">
+                <div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;">
+                  <div class="wistia_embed wistia_async_u8up7h2m32 videoFoam=true" style="height:100%;position:relative;width:100%">
+                    <div class="wistia_swatch" style="height:100%;left:0;opacity:0;overflow:hidden;position:absolute;top:0;transition:opacity 200ms;width:100%;">
+                      <img src="https://fast.wistia.com/embed/medias/u8up7h2m32/swatch" style="filter:blur(5px);height:100%;object-fit:contain;width:100%;" alt="" aria-hidden="true" onload="this.parentNode.style.opacity=1;"/>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
 
-            <%= f.submit 'Start Hacking', :class => 'submit-btn', :html => {:data => {:js => 'submit'}} %>
+            <%= f.submit 'Start Hacking', :class => 'submit-btn' %>
             <div data-js="back" class="submit-btn btn-back">Back</div>
           </end>
         <% end %>

--- a/app/views/users/registration.html.erb
+++ b/app/views/users/registration.html.erb
@@ -66,7 +66,7 @@
           </div>
 
           <div id="form-second" class="hidden">
-            <p>Before you get started, learn how to create a quality pull request:</p>
+            <p>Before you get started, learn how to create a quality pull request. <strong>You must watch the full video before moving on to the registration steps below.</strong></p>
             <br>
             <div class="beginners-video">
               <script src="https://fast.wistia.com/embed/medias/u8up7h2m32.jsonp" async></script>

--- a/app/views/users/registration.html.erb
+++ b/app/views/users/registration.html.erb
@@ -1,15 +1,16 @@
 <section class="section reg-content">
   <div class="container">
     <div class="registration-wrapper">
-        <div class="registration-left">
-          <div class="register-header">Register</div>
-          <h1 class="title is-1">About you</h1>
-          <p>
-            Please select which email address you’d like to use for Hacktoberfest and read the
-            <a target="_blank" href="/details#rules">rules and values</a>.
-          </p>
+      <div class="registration-left">
+        <div class="register-header">Register</div>
+        <h1 class="title is-1">About you</h1>
+        <p>
+          Please select which email address you’d like to use for Hacktoberfest and read the
+          <a target="_blank" href="/details#rules">rules and values</a>.
+        </p>
 
-          <%= form_for :user, url: {action: 'register'}, method: :patch do |f| %>
+        <%= form_for :user, url: {action: 'register'}, method: :patch do |f| %>
+          <div id="form-first">
             <%= render partial: 'users/dropdowns', locals: { f: f, u: User.new } %>
 
             <div class="checkboxes">
@@ -49,34 +50,39 @@
             <div class="field">
               <div class="control">
                 <label class="checkbox">
-                  <%= f.check_box :terms_acceptance, {:class => 'check-style', :required => true} %>
+                  <%= f.check_box :terms_acceptance, {:class => 'check-style'} %>
                   I have read and understand the
                   <a target="_blank" href="/details#rules">Rules and Values</a>.
                 </label>
               </div>
             </div>
+            <div data-js="continue" class="submit-btn btn-sml">Continue</div>
+          </div>
 
-            <%= f.submit 'Start Hacking', :class => 'submit-btn' %>
-          <% end %>
-        </div>
+          <div id="form-second" class="hidden">
 
-      <div class="registration-right">
-        <div class="info-pane">
-          <h3>Do's and Dont's of Hacktoberfest</h3>
-          <div class="info-pane-item dont">
-            <h2>Don't: open PR's with tiny text edits on other people's repositories</h2>
-            <p>If you're looking for a fast way to open four PR's and win, <a href="#">there's a better way!</a></p>
-          </div>
-          <div class="info-pane-item do">
-            <h2>Do: Follow a repo's contribution guidelines</h2>
-            <p>Almost every repo looking for help has a <code>CONTRIBUTING.md</code> file in it, <em>read it first!</em></p>
-          </div>
-          <div class="info-pane-item dont">
-            <h2>Don't: feel intimidated</h2>
-            <p><a href="#">Register for an event</a> and learn with a group, or <a href="#">join the discord chat</a> to connect with others.</p>
-          </div>
-        </section>
+            <%= f.submit 'Start Hacking', :class => 'submit-btn', :html => {:data => {:js => 'submit'}} %>
+            <div data-js="back" class="submit-btn btn-back">Back</div>
+          </end>
+        <% end %>
       </div>
     </div>
+    <div class="registration-right">
+      <div class="info-pane">
+        <h3>Do's and Dont's of Hacktoberfest</h3>
+        <div class="info-pane-item dont">
+          <h2>Don't: open PR's with tiny text edits on other people's repositories</h2>
+          <p>If you're looking for a fast way to open four PR's and win, <a href="#">there's a better way!</a></p>
+        </div>
+        <div class="info-pane-item do">
+          <h2>Do: Follow a repo's contribution guidelines</h2>
+          <p>Almost every repo looking for help has a <code>CONTRIBUTING.md</code> file in it, <em>read it first!</em></p>
+        </div>
+        <div class="info-pane-item dont">
+          <h2>Don't: feel intimidated</h2>
+          <p><a href="#">Register for an event</a> and learn with a group, or <a href="#">join the discord chat</a> to connect with others.</p>
+        </div>
+      </div>
+    </div>  
   </div>
 </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -39,7 +39,30 @@
       <% elsif @presenter.scoring_pull_requests.empty? %>
         <div class="container pre-launch-container">
           <h2 class='title is-2'>You haven't made any pull requests yet.</h2>
-          <%= link_to "Get started", details_path, anchor: "getting-started", class: "button-static" %>
+          <p>Here are some ideas to get you started:</p>
+          <div class="idea-set">
+            <div class="idea-pane" data-label="Fastest way to win T-Shirt">
+              <h3>Fork our repo and open your own PR's</h3>
+              <p>Not ready yet to get involved as a contributor on an open source project? This guide walks you through making your own Open Source repo and opening your first 4 PR's to win the contest.</p>
+              <%= link_to "Get started", "https://www.digitalocean.com/community/tutorials/how-to-create-a-pull-request-on-github", class: "button-static" %>
+            </div>
+            <div class="idea-pane">
+              <h3>Find ideas in tagged issues</h3>
+              <p>This guide includes links to several sites that let you search and filter for issues that have been flagged as good first issues.</p>
+              <%= link_to "Find an issue", details_path, anchor: "beginners", class: "button-static" %>
+            </div>
+            <div class="idea-pane">
+              <h3>Register for an event</h3>
+              <p>Join a live event and work through creating your Pull Requests together as a group! Many events this year are 100% virtual.</p>
+              <%= link_to "Attend an event", events_path, class: "button-static" %>
+            </div>
+            <div class="idea-pane">
+              <h3>Join the Hacktoberfest chat</h3>
+              <p>Join the official Hacktoberfest Discord server to connect with other participants, trade ideas and get help.</p>
+              <%= link_to "Join chat server", "https://discord.gg/hacktoberfest", class: "button-static" %>
+            </div>
+          </div>
+          
         </div>
       <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -41,25 +41,25 @@
           <h2 class='title is-2'>You haven't made any pull requests yet.</h2>
           <p>Here are some ideas to get you started:</p>
           <div class="idea-set">
-            <div class="idea-pane" data-label="Fastest way to win T-Shirt">
-              <h3>Fork our repo and open your own PR's</h3>
-              <p>Not ready yet to get involved as a contributor on an open source project? This guide walks you through making your own Open Source repo and opening your first 4 PR's to win the contest.</p>
-              <%= link_to "Get started", "https://www.digitalocean.com/community/tutorials/how-to-create-a-pull-request-on-github", class: "button-static" %>
+            <div class="idea-pane">
+              <h3>Attend an Event</h3>
+              <p>Don’t hack alone. Join a virtual event and create your pull requests with others.</p>
+              <%= link_to "Find Events", "/events", class: "button-static" %>
             </div>
             <div class="idea-pane">
               <h3>Find ideas in tagged issues</h3>
-              <p>This guide includes links to several sites that let you search and filter for issues that have been flagged as good first issues.</p>
+              <p>Check out these links for good first issues that will qualify for the Hacktoberfest challenge.</p>
               <%= link_to "Find an issue", details_path, anchor: "beginners", class: "button-static" %>
             </div>
             <div class="idea-pane">
-              <h3>Register for an event</h3>
-              <p>Join a live event and work through creating your Pull Requests together as a group! Many events this year are 100% virtual.</p>
-              <%= link_to "Attend an event", events_path, class: "button-static" %>
+              <h3>Join the Hacktoberfest Discord</h3>
+              <p>Connect with other participants, share ideas and get the help you need to complete the challenge.</p>
+              <%= link_to "Attend an event", "https://discord.gg/hacktoberfest", class: "button-static" %>
             </div>
             <div class="idea-pane">
-              <h3>Join the Hacktoberfest chat</h3>
-              <p>Join the official Hacktoberfest Discord server to connect with other participants, trade ideas and get help.</p>
-              <%= link_to "Join chat server", "https://discord.gg/hacktoberfest", class: "button-static" %>
+              <h3>Fork your own repo with your own PRs</h3>
+              <p>Not ready to contribute to an open source project? View this guide to making your own repo and creating pull requests to complete the challenge.</p>
+              <%= link_to "Get started", "https://www.digitalocean.com/community/tutorials/how-to-create-a-pull-request-on-github", class: "button-static" %>
             </div>
           </div>
           
@@ -102,25 +102,20 @@
       <% end %>
     </div>
     <div class="education-wrapper">
-      <h4 class="side-headers">education hub</h4>
-      <div class="education-section">
-        <h5>Educate Yourself</h5>
-        <ul>
-          <li><a href="https://www.digitalocean.com/community/tutorial_series/an-introduction-to-open-source" target="_blank">Get An Introduction to Open Source</a></li>
-          <li><a href="https://hacktoberfest.digitalocean.com/details/" target="_blank">Digest the Resources</a></li>
-          <li><a href="https://hacktoberfest.digitalocean.com/faq/" target="_blank">Get Answers Before Asking</a></li>
-          <li><a href="https://www.digitalocean.com/community/tutorials/how-to-maintain-open-source-software-projects" target="_blank">Learn About Maintainer Experience</a></li>
-          <li><a href="https://raise.dev/hacktoberfest" target="_blank">Get help from the Helpdesk</a></li>
-        </ul>
-      </div>
-      <div class="education-section">
-        <h5>Make An Impact</h5>
-        <ul>
-          <li><a href="https://hacktoberfest.digitalocean.com/eventkit/" target="_blank">Organize a Hacktoberfest Meetup</a></li>
-          <li><a href="https://www.digitalocean.com/community/meetup_kits/hacktoberfest-workshop-kit-how-to-submit-your-first-pull-request-on-github" target="_blank">Lead an Open Source Workshop</a></li>
-          <li><a href="https://dev.to/" target="_blank">Share Your Experience on DEV</a></li>
-          <li><a href="https://raise.dev/hacktoberfest" target="_blank">Answer questions on the Helpdesk</a></li>
-        </ul>
+      <div class="info-pane">
+        <h3>Do's and Dont's of Hacktoberfest</h3>
+        <div class="info-pane-item dont">
+          <h2>Don't: open pull requests with minor text edits on other people's repositories</h2>
+          <p>If you're looking for a faster way to open four PR's and win, <a href="#">there's a better way!</a></p>
+        </div>
+        <div class="info-pane-item do">
+          <h2>Do: Follow a repository's contribution guidelines</h2>
+          <p>Almost every repo looking for help has a <code>CONTRIBUTING.md</code> file in it, <em>read it first!</em></p>
+        </div>
+        <div class="info-pane-item dont">
+          <h2>Don't: feel intimidated</h2>
+          <p><a href="#">Register for an event</a> and learn with a group, or connect with others in the Discord chat.</p>
+        </div>
       </div>
     </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -114,7 +114,7 @@
         </div>
         <div class="info-pane-item dont">
           <h2>Don't: feel intimidated</h2>
-          <p><a href="#">Register for an event</a> and learn with a group, or connect with others in the Discord chat.</p>
+          <p><a href="/events">Register for an event</a> and learn with a group, or connect with others in the Discord chat.</p>
         </div>
       </div>
     </div>

--- a/db/migrate/20201002195234_add_quality_acceptance_to_users.rb
+++ b/db/migrate/20201002195234_add_quality_acceptance_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddQualityAcceptanceToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :quality_acceptance, :boolean, default: false
+  end
+end

--- a/db/migrate/20201002195525_add_disqualify_acceptance_to_users.rb
+++ b/db/migrate/20201002195525_add_disqualify_acceptance_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDisqualifyAcceptanceToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :disqualify_acceptance, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_22_155319) do
+ActiveRecord::Schema.define(version: 2020_10_02_195525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,6 +124,8 @@ ActiveRecord::Schema.define(version: 2020_09_22_155319) do
     t.boolean "dev_marketing_emails", default: false
     t.string "category", default: "participant"
     t.string "country"
+    t.boolean "quality_acceptance", default: false
+    t.boolean "disqualify_acceptance", default: false
   end
 
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -7,6 +7,8 @@ FactoryBot.define do
     uid               { rand(1..1_000_000) }
     provider_token    { user_github_token }
     terms_acceptance  { true }
+    quality_acceptance { true }
+    disqualify_acceptance { true }
     state             { 'registered' }
     country           { 'US' }
 


### PR DESCRIPTION
# Description
This is a follow-up on the changes proposed as part of the "reduce spam" initiative.

The goal of these changes is to route people who don't want to genuinely contribute to Open Source into creating PR's on their own repos instead of spammy PR's on big open source repos.

Step 1 of registration UI:
![image](https://user-images.githubusercontent.com/11527560/94778284-f2e2f200-0392-11eb-89f3-1707a880c81a.png)

Empty state UI post-registration:
![image](https://user-images.githubusercontent.com/11527560/94778305-feceb400-0392-11eb-979c-b404779525bf.png)

## What's still needed: We need a callout when a user has one or more PR's, and maybe a callout when a user has a PR that has been marked as spam or invalid?


# Test process

- [ ] Register with a new account, confirm that you see the Do's and Don'ts and they display correctly in light mode and dark mode.
- [ ] Go to profile page, confirm that you see the suggestion panels and they display correctly in light mode and dark mode.
- [ ] Confirm that all links work.
- [ ] Confirm that new required fields must be checked before user can register (`quality_acceptance`, `disqualify_acceptance`)
- [ ] Confirm that these fields cannot be checked until video has finished playing.
- [ ] Confirm copy meets new requirements.
- [ ] Confirm mobile view works.

# Requirements to merge
<!--
Ensure your pull request meets all the requirements for merging. Place an `x` in each box to indicate that your pull request meets that requirement.
-->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
