### PR TITLE
Skip Airtable updater service spec on forks

### DIFF
--- a/spec/services/report_airtable_updater_service_spec.rb
+++ b/spec/services/report_airtable_updater_service_spec.rb
@@ -52,9 +52,11 @@ describe ReportAirtableUpdaterService do
           ReportAirtableUpdaterService.call(report)
         end
 
-        it 'writes to airtable', :vcr do
-          VCR.use_cassette 'ReportAirtableUpdaterService/_call/the_repository_does_exist/the_repository_is_not_already_marked_as_spam/writes_to_airtable' do
-            expect(a_request(:post, AIRTABLE_URI_REGEX)).to have_been_made
+        if ENV['AIRTABLE_APP_ID'].present?
+          it 'writes to airtable', :vcr do
+            VCR.use_cassette 'ReportAirtableUpdaterService/_call/the_repository_does_exist/the_repository_is_not_already_marked_as_spam/writes_to_airtable' do
+              expect(a_request(:post, AIRTABLE_URI_REGEX)).to have_been_made
+            end
           end
         end
       end

--- a/spec/services/report_airtable_updater_service_spec.rb
+++ b/spec/services/report_airtable_updater_service_spec.rb
@@ -53,7 +53,7 @@ describe ReportAirtableUpdaterService do
         end
 
         it 'writes to airtable', :vcr do
-          VCR.use_cassette 'ReportAirtableUpdaterService/_call/the_repository_does_exist/the_repository_is_not_already_marked_as_spam' do
+          VCR.use_cassette 'ReportAirtableUpdaterService/_call/the_repository_does_exist/the_repository_is_not_already_marked_as_spam/writes_to_airtable' do
             expect(a_request(:post, AIRTABLE_URI_REGEX)).to have_been_made
           end
         end


### PR DESCRIPTION
# Description
Forks of the project were running into the following error on the `report_airtable_updater_service`:
```
   URI::InvalidURIError:
       bad URI(is not URI?): https://api.airtable.com/v0/<TEST_AIRTABLE_APP_ID>/Spam%20Repos
```
This update makes that spec ENV var dependent.

# Test process
Create a fork of the project, leave Airtable keys blank, and run the test suite with `./script/test-command.sh bundle exec rspec` and you should see the error above. 

Run the same test on the branch and the error should be gone.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
