### PR TITLE
Require pull requests be accepted

### DIFF
--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -8,12 +8,12 @@ class PullRequest < ApplicationRecord
 
   state_machine initial: :new do
     event :spam_repo do
-      transition %i[new waiting] => :spam_repo,
+      transition %i[new created waiting] => :spam_repo,
                  if: ->(pr) { pr.spammy? }
     end
 
     event :invalid_label do
-      transition %i[new waiting] => :invalid_label,
+      transition %i[new created waiting] => :invalid_label,
                  if: ->(pr) { pr.labelled_invalid? }
     end
 
@@ -27,13 +27,13 @@ class PullRequest < ApplicationRecord
     # A pull request that has been opened and accepted, not spammy & newer than 7 days
     # Once here a pull request can go back to created if un-accepted (possible if the accepted label is removed)
     event :waiting do
-      transition %i[new spam_repo invalid_label] => :waiting,
+      transition %i[new created spam_repo invalid_label] => :waiting,
                  if: ->(pr) { !pr.spammy_or_invalid? && !pr.older_than_week? && pr.is_accepted? }
     end
 
     # A pull request that has been opened, not spammy, not accepted
     event :created do
-      transition %i[new spam_repo invalid_label waiting] => :created,
+      transition %i[new waiting spam_repo invalid_label] => :created,
                  if: ->(pr) { !pr.spammy_or_invalid? && !pr.older_than_week? && !pr.is_accepted? }
     end
 

--- a/spec/support/pull_request_filter_helper.rb
+++ b/spec/support/pull_request_filter_helper.rb
@@ -142,7 +142,7 @@ LONG_SPAM_LABEL_PR = {
   'repository' => { 'databaseId' => 123 }
 }.freeze
 
-ELIGIBLE_PR = {
+ELIGIBLE_MERGED_PR = {
   'id' => 'MDExOlB1bGxSZXF1ZXN0NTE0MTg4ODg=',
   'title' => 'Update README.md',
   'body' =>
@@ -152,13 +152,14 @@ ELIGIBLE_PR = {
   # This is valid, eligible
   'createdAt' => (Time.zone.parse(ENV['NOW_DATE']) - 9.days).to_s,
   'labels' => { 'edges' => [] },
+  'merged' => true,
   'repository' => { 'databaseId' => 123 }
 }.freeze
 
 # 5 pull requests with 3 valid dates & 2 invalid labels
 ARRAY_WITH_INVALID_LABEL = [
   INVALID_EMOJI_LABEL_PR,
-  ELIGIBLE_PR,
+  ELIGIBLE_MERGED_PR,
   { 'id' => 'MDExOlB1bGxSZXF1ZXN0NjkyNjE4Mjk=',
     'title' => 'Add natural layer',
     'body' =>
@@ -266,7 +267,19 @@ MATURE_ARRAY = [
     'repository' => { 'databaseId' => 123 } }
 ].freeze
 
-IMMATURE_PR = {
+CREATED_PR = {
+    'id' => 'MDExOlB1bGxSZXF1ZXN0NDc0Nzk5ODQ=',
+    'title' => 'Results by cookie',
+    'body' =>
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim.',
+    'url' => 'https://github.com/peek/peek/pull/79',
+    'createdAt' => (Time.zone.parse(ENV['NOW_DATE']) - 2.days).to_s,
+    'labels' => { 'edges' => [] },
+    'repository' => { 'databaseId' => 123 }
+}.freeze
+
+IMMATURE_MERGED_PR = {
   'id' => 'MDExOlB1bGxSZXF1ZXN0NDc0Nzk5ODQ=',
   'title' => 'Results by cookie',
   'body' =>
@@ -275,7 +288,20 @@ IMMATURE_PR = {
   'url' => 'https://github.com/peek/peek/pull/79',
   'createdAt' => (Time.zone.parse(ENV['NOW_DATE']) - 2.days).to_s,
   'labels' => { 'edges' => [] },
+  'merged' => true,
   'repository' => { 'databaseId' => 123 }
+}.freeze
+
+IMMATURE_ACCEPTED_PR = {
+    'id' => 'MDExOlB1bGxSZXF1ZXN0NDc0Nzk5ODQ=',
+    'title' => 'Results by cookie',
+    'body' =>
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim.',
+    'url' => 'https://github.com/peek/peek/pull/79',
+    'createdAt' => (Time.zone.parse(ENV['NOW_DATE']) - 2.days).to_s,
+    'labels' => { 'edges': [{ 'node': { 'name': 'hacktoberfest-Accepted' } }] },
+    'repository' => { 'databaseId' => 123 }
 }.freeze
 
 IMMATURE_INVALID_MERGED_PR = {
@@ -295,7 +321,7 @@ IMMATURE_INVALID_MERGED_PR = {
 
 # 4 pull requests with timestamps less than 7 days old, maturing
 IMMATURE_ARRAY = [
-  IMMATURE_PR,
+    IMMATURE_MERGED_PR,
   { 'id' => 'MDExOlB1bGxSZXF1ZXN0NTE0MTg4ODg=',
     'title' => 'Update README.md',
     'body' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do


### PR DESCRIPTION
# Description

To reduce drive-by spam and workload on maintainers to deal with spam, this makes it required that a pull request is merged or labelled as `hacktoberfest-accepted` to qualify. This should to an extent make Hacktoberfest opt-in for maintainers and should discourage users from making spammy PRs on legitimate projects as they won't count unless merged.

# Test process

TBD.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
