### PR TITLE
Fix dark mode link color overriding button color

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -301,7 +301,7 @@ $navColor: rgba(0, 0, 0, 0);
 
 body.dark {
   #navbar {
-    .navLink:hover {
+    .navLink:not(.button):hover {
       color: $dark-highlightColor !important;
     }
   }


### PR DESCRIPTION
# Description

When viewing the homepage as a logged-out user the "start hacking" button text color should be white when hovered, but instead it's overridden by the color applied to all navigation links when dark-mode is enabled. This makes the contrast between the background-color of the button and the text poor. It also doesn't match the style of similar buttons.

https://share.getcloudapp.com/kpuwQPp1

To fix I added a negation (`:not(.button)`) to the css that was applying the dark-mode color to all navigation links. This will exclude links which are also buttons.

# Test process

Go to the [hacktoberfest homepage](https://hacktoberfest.digitalocean.com/) as a logged out user and enable dark-mode. Hover over the "start hacking" button in the header navigation to see its color.

# Requirements to merge
<!--
Ensure your pull request meets all the requirements for merging. Place an `x` in each box to indicate that your pull request meets that requirement.
-->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
