### PR TITLE
Update MLH caching method

### DIFF
--- a/app/services/mlh_table.rb
+++ b/app/services/mlh_table.rb
@@ -23,7 +23,6 @@ class MlhTable
       response.body do
         ActiveSupport::Cache.lookup_store(
           *Rails.configuration.cache_store,
-          namespace: 'mlh',
           expires_in: 3.hours
         )
       end

--- a/app/services/mlh_table.rb
+++ b/app/services/mlh_table.rb
@@ -4,7 +4,7 @@ class MlhTable
   attr_accessor :api_url
 
   def initialize
-    @api_url = 'https://organize.mlh.io/api/v2/events?type=hacktoberfest-2020'
+    @api_url = 'https://organize.mlh.io/api/v2/events?type=hacktoberfest-2020/wrong-wrong'
   end
 
   def faraday_connection
@@ -18,7 +18,7 @@ class MlhTable
       faraday.use Faraday::Response::RaiseError
       faraday.adapter Faraday.default_adapter
       unless Rails.configuration.cache_store == :null_store
-        faraday.response :caching do    
+        faraday.response :caching do
           ActiveSupport::Cache.lookup_store(
             *Rails.configuration.cache_store,
             namespace: 'mlh',
@@ -27,8 +27,9 @@ class MlhTable
         end
       end
     end
+    response = @faraday_connection.get
     return response.body if response.success?
-
+  rescue StandardError
     { 'data' => AirtablePlaceholderService.call('Meetups') }
   end
 

--- a/app/services/mlh_table.rb
+++ b/app/services/mlh_table.rb
@@ -4,7 +4,7 @@ class MlhTable
   attr_accessor :api_url
 
   def initialize
-    @api_url = 'https://organize.mlh.io/api/v2/events?type=hacktoberfest-2020/wrong-wrong'
+    @api_url = 'https://organize.mlh.io/api/v2/events?type=hacktoberfest-2020'
   end
 
   def faraday_connection

--- a/app/services/mlh_table.rb
+++ b/app/services/mlh_table.rb
@@ -17,14 +17,14 @@ class MlhTable
     ) do |faraday|
       faraday.use Faraday::Response::RaiseError
       faraday.adapter Faraday.default_adapter
-    end
-    response = @faraday_connection.get
-    unless Rails.configuration.cache_store == :null_store
-      response.body do
-        ActiveSupport::Cache.lookup_store(
-          *Rails.configuration.cache_store,
-          expires_in: 3.hours
-        )
+      unless Rails.configuration.cache_store == :null_store
+        faraday.response :caching do    
+          ActiveSupport::Cache.lookup_store(
+            *Rails.configuration.cache_store,
+            namespace: 'mlh',
+            expires_in: 3.hours
+          )
+        end
       end
     end
     return response.body if response.success?

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,8 +13,8 @@ Rails.application.configure do
 
   config.log_level = :debug
 
-  if ENV['DALLI_SERVER'].presence
-    config.cache_store = :dalli_store, *ENV['DALLI_SERVER']
+  if ENV['REDIS_HOST'].presence
+    config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
     config.action_controller.perform_caching = true
   else
     config.action_controller.perform_caching = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,8 +13,8 @@ Rails.application.configure do
 
   config.log_level = :debug
 
-  if ENV['REDIS_HOST'].presence
-    config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
+  if ENV['DALLI_SERVER'].presence
+    config.cache_store = :dalli_store, *ENV['DALLI_SERVER']
     config.action_controller.perform_caching = true
   else
     config.action_controller.perform_caching = false


### PR DESCRIPTION
# Description
Our caching to MLH wasn't working as expected. Changes in this PR should ensure the API call is cached properly.

# Test process
I tested this by looking at local cache in `tmp/cache` and ensuring that Airtable and MLH keys/entries were created. To configure that, you can tweak the settings in `development.rb`, swapping `config.cache_store = :file_store, "#{root}/tmp/cache/"` in place of `config.cache_store = :dalli_store, *ENV['DALLI_SERVER']`.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
