### PR TITLE
Fix link to issue search not showing only open issues

### DIFF
--- a/app/views/pages/homepage/active_homepage.html.erb
+++ b/app/views/pages/homepage/active_homepage.html.erb
@@ -114,7 +114,7 @@
           <%= render partial: 'languages/all_projects', locals: {projects: @projects} %>
         </div>
       <% end %>
-      <a href="https://github.com/search?q=label%3Ahacktoberfest+state%3Aopen+no%3Aassignee+is%3Aissue&type=Issues" class="button">
+      <a href="https://github.com/search?q=label%3Ahacktoberfest+no%3Aassignee+is%3Aissue&state=open" class="button">
         Browse <%= @projects.empty? ? 'projects' : 'more' %> on GitHub
       </a>
     </div>


### PR DESCRIPTION
# Description

I noticed the link on the home page is redirecting to a search page showing all issues, even the closed ones. It seems like the `state:open` parameter in the query is not executed. So i moved it to the general params. Also, the parameter `&type=Issues` had no effect as it is already represented by the search value `is:issue` 

# Requirements to merge
<!--
Ensure your pull request meets all the requirements for merging. Place an `x` in each box to indicate that your pull request meets that requirement.
-->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
