### PR TITLE
Support PR-specific opt-in

### DIFF
--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -101,6 +101,9 @@ class PullRequest < ApplicationRecord
     # Don't have this requirement for old PRs
     return true if created_at <= Hacktoberfest.rules_date
 
+    # PR-specific opt-in
+    return true if labelled_accepted?
+
     repository_topics.select { |topic| topic.strip == 'hacktoberfest' }.any?
   end
 

--- a/app/views/pages/details.html.erb
+++ b/app/views/pages/details.html.erb
@@ -70,8 +70,13 @@
         <li>Maintainers can opt-in to participate by 
           <a href="https://do.co/hfest-topics">classifying their projects with the <code>hacktoberfest</code> topic</a>.
         </li>
-        <li>Your pull requests will count toward your participation once they have been merged, approved by
-          a maintainer or labelled as <code>hacktoberfest-accepted</code>.
+        <li>Your pull requests will count toward your participation if they are in a repository with the
+          <code>hacktoberfest</code> topic and once they have been merged, approved by a maintainer or labelled as
+          <code>hacktoberfest-accepted</code>.
+        </li>
+        <li>Additionally, any pull request with the <code>hacktoberfest-accepted</code> label, submitted to any public
+          GitHub repository, with or without the <code>hacktoberfest</code> topic, will be considered valid for
+          Hacktoberfest.
         </li>
         <li>You can sign up anytime between October 1 and October 31. Just be sure to sign up on the official
           Hacktoberfest website for your pull requests to count.
@@ -92,6 +97,9 @@
       <p>Pull requests following the rule change must be to a participating public repository on GitHub, and have been 
         merged, labelled as <code>hacktoberfest-accepted</code>, or approved.
       </p>
+      <p>Pull requests labelled as <code>hacktoberfest-accepted</code> will count toward to Hacktoberest from any public
+        repository on GitHub, with or without the <code>hacktoberfest</code> topic.
+      </p>
       <p>The pull request must contain commits you made yourself. If a maintainer reports your pull request as spam, 
         it will not be counted toward your participation in Hacktoberfest. If a maintainer reports behavior that’s 
         not in line with the values of Hacktoberfest or the project’s code of conduct, you will be ineligible to
@@ -100,12 +108,13 @@
       <p>To put it in terms that some folks will more easily understand:</p>
       <blockquote>
         PRs count if:
-        <br>Submitted in a repo with the <code>hacktoberfest</code> topic AND
-        <br>during the month of October AND (
-        <br>&nbsp;&nbsp;The PR is merged OR
-        <br>&nbsp;&nbsp;The PR is labelled as <code>hacktoberfest-accepted</code> by a maintainer OR
-        <br>&nbsp;&nbsp;The PR has been approved
-        <br>)
+        <br/>Submitted during the month of October AND (
+        <br/>&nbsp;&nbsp;The PR is labelled as <code>hacktoberfest-accepted</code> by a maintainer OR
+        <br/>&nbsp;&nbsp;Submitted in a repo with the <code>hacktoberfest</code> topic AND (
+        <br/>&nbsp;&nbsp;&nbsp;&nbsp;The PR is merged OR
+        <br/>&nbsp;&nbsp;&nbsp;&nbsp;The PR has been approved
+        <br/>&nbsp;&nbsp;)
+        <br/>)
       </blockquote>
     </section>
 

--- a/app/views/pages/details_resources/_maintainers_resources.html.erb
+++ b/app/views/pages/details_resources/_maintainers_resources.html.erb
@@ -10,8 +10,14 @@
           community project to apply the topic to multiple repositories</a>.
         </p>
         <p>
-          Pull requests will only count toward completing Hacktoberfest if they are merged, labelled as 
-          <code>hacktoberfest-accepted</code>, or approved by a maintainer of the project before November 1.
+          Pull requests will only count toward completing Hacktoberfest if they are in a repository with the
+          <code>hacktoberfest</code> topic and are merged, labelled as <code>hacktoberfest-accepted</code>, or approved
+          by a maintainer of the project before November 1.
+        </p>
+        <p>
+          Alternatively, if as a maintainer you don't have access to add the <code>hacktoberfest</code> topic, or don't
+          want to, you can instead opt-in a specific pull request on any public GitHub repository by applying the
+          <code>hacktoberfest-accepted</code> label.
         </p>
         <p>
           Check out DigitalOcean’s

--- a/app/views/pages/hacktoberfest_update.html.erb
+++ b/app/views/pages/hacktoberfest_update.html.erb
@@ -3,25 +3,28 @@
 
     <h1 class="title">UPDATED: An update on efforts to reduce spam with Hacktoberfest: introducing maintainer opt-in and more.</h1>
 
-    <p><em>Updated at 10/03/2020 02:30 UTC</em></p>
-    
+    <p><em>Posted at 10/03/2020 02:30 UTC</em></p>
+
+    <p><i>Updated (10/05/2020 15:00 UTC): Individual pull requests can also be directly opted-in to Hacktoberfest with the ‘hacktoberfest-accepted’ label, on any public GitHub repository, without the need for the ‘hacktoberfest’ repository topic.</i></p>
+
     <p>Thank you to everyone who has reached out with ideas and suggestions to help Hacktoberfest live its values of celebrating and fostering the open source community.</p>
 
     <p>After working closely with our friends at GitHub, we are happy to introduce a new measure to help significantly reduce the amount of spammy contribution. <strong>We’re making Hacktoberfest opt-in only for projects – which maintainers can do simply by adding the ‘hacktoberfest’ topic to a repository.</strong></p>
 
     <p>This was one of the primary requests from maintainers and we are hopeful that it will help alleviate some of the issues you've been facing.</p>
     
-    <p>We will honor all valid pull requests prior to this change, and as of October 3, 2020 at 12:00:00 UTC – and October 3 in <em>all</em> time zones – pull requests will only count toward earning a T-shirt or planting a tree if they are submitted in a repository classified with the <a href="https://github.com/topics/hacktoberfest">‘hacktoberfest’ topic</a>. The pull requests will also need to be merged, approved by a maintainer, or labeled as ‘hacktoberfest-accepted’ in order to qualify. The deadline for completions, merging, labeling, and approving is November 1.</p>
+    <p>We will honor all valid pull requests prior to this change, and as of October 3, 2020 at 12:00:00 UTC – and October 3 in <em>all</em> time zones – pull requests will only count toward earning a T-shirt or planting a tree if they are labeled as ‘hacktoberfest-accepted’ by a maintainer, or submitted in a repository classified with the <a href="https://github.com/topics/hacktoberfest">‘hacktoberfest’ topic</a>. Pull requests in repositories with the ‘hacktoberfest’ topic will also need to be merged, approved by a maintainer, or labeled as ‘hacktoberfest-accepted’ in order to qualify. The deadline for completions, merging, labeling, and approving is November 1.</p>
 
     <p>To put it in terms that folks will more easily understand:</p>
 
     <blockquote>
       PRs count if:
-      <br/>Submitted in a repo with the <code>hacktoberfest</code> topic AND
-      <br/>during the month of October AND (
-      <br/>&nbsp;&nbsp;The PR is merged OR
+      <br/>Submitted during the month of October AND (
       <br/>&nbsp;&nbsp;The PR is labelled as <code>hacktoberfest-accepted</code> by a maintainer OR
-      <br/>&nbsp;&nbsp;The PR has been approved
+      <br/>&nbsp;&nbsp;Submitted in a repo with the <code>hacktoberfest</code> topic AND (
+      <br/>&nbsp;&nbsp;&nbsp;&nbsp;The PR is merged OR
+      <br/>&nbsp;&nbsp;&nbsp;&nbsp;The PR has been approved
+      <br/>&nbsp;&nbsp;)
       <br/>)
     </blockquote>
 

--- a/app/views/users/show/_timeline.html.erb
+++ b/app/views/users/show/_timeline.html.erb
@@ -91,7 +91,9 @@
             Ineligible Repository
           </div>
           <div class="icon-desc">
-            Your PR was submitted to a repository that is not participating in Hacktoberfest. Maintainers of the repository can add the "hacktoberfest" topic to their repository if they wish to participate.
+            Your PR was submitted to a repository that is not participating in Hacktoberfest.
+            Maintainers of the repository can add the "hacktoberfest" topic to their repository if they wish to participate.
+            Alternatively, an individual PR can be opted-in with a maintainer adding the "hacktoberfest-accepted" label to the PR.
           </div>
         </div>
       </div>

--- a/spec/support/pull_request_filter_helper.rb
+++ b/spec/support/pull_request_filter_helper.rb
@@ -220,9 +220,7 @@ ELIGIBLE_PR = {
   'labels' => { 'edges': [{ 'node': { 'name': 'hacktoberfest-accepted' } }] },
   'repository' => {
     'databaseId' => 123,
-    'repositoryTopics' => { 'edges': [
-      { 'node': { 'topic': { 'name': 'Hacktoberfest' } } }
-    ] }
+    'repositoryTopics' => { 'edges' => [] }
   }
 }.freeze
 
@@ -376,9 +374,7 @@ VALID_ARRAY = [
     'labels' => { 'edges': [{ 'node': { 'name': 'hacktoberfest-accepted' } }] },
     'repository' => {
       'databaseId' => 123,
-      'repositoryTopics' => { 'edges': [
-        { 'node': { 'topic': { 'name': 'Hacktoberfest' } } }
-      ] }
+      'repositoryTopics' => { 'edges' => [] }
     } }
 ].freeze
 
@@ -541,9 +537,7 @@ LARGE_IMMATURE_ARRAY = [
     'labels' => { 'edges': [{ 'node': { 'name': 'hacktoberfest-accepted' } }] },
     'repository' => {
       'databaseId' => 123,
-      'repositoryTopics' => { 'edges': [
-        { 'node': { 'topic': { 'name': 'Hacktoberfest' } } }
-      ] }
+      'repositoryTopics' => { 'edges' => [] }
     } },
   { 'id' => 'MDExOlB1bGxSZXF1ZXN0NTE0MTg4ODg=',
     'title' => 'Update README.md',


### PR DESCRIPTION
# Description

Allow individual PRs to opt-in to the event with the `hacktoberfest-accepted` label, without the repository having the `hacktoberfest` topic.

Updated post copy:

![image](https://user-images.githubusercontent.com/12371363/95093616-e0651180-0720-11eb-8923-3be61a4cd66c.png)

Updated details:

![image](https://user-images.githubusercontent.com/12371363/95095070-81080100-0722-11eb-888f-b839b8ba53e3.png)

Updated rules:

![image](https://user-images.githubusercontent.com/12371363/95095092-87967880-0722-11eb-82ae-955e8bd189be.png)

Updated maintainers info:

![image](https://user-images.githubusercontent.com/12371363/95095132-91b87700-0722-11eb-8fae-9422523c823f.png)

Updated timeline legend:

![image](https://user-images.githubusercontent.com/12371363/95095566-1c00db00-0723-11eb-86a4-569dd4c59e6e.png)


# Test process

- Create PR in non-Hacktoberfest-topic repo with no labels, shows as missing topic
- Create PR in non-Hacktoberfest-topic repo with `hacktoberfest-accepted` label, shows as waiting
- Create PR in Hacktoberfest-topic repo with no labels, shows as not accepted
- Create PR in Hacktoberfest-topic repo with `hacktoberfest-accepted` label, shows as waiting

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
