### PR TITLE
Include waiting PRs in bonus score

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -170,6 +170,11 @@ class User < ApplicationRecord
     score > 4 ? 4 : score
   end
 
+  def bonus_score
+    score = waiting_or_eligible_pull_requests_count - 4
+    score < 0 ? 0 : score
+  end
+
   delegate :scoring_pull_requests, :non_scoring_pull_requests,
            :scoring_pull_requests_receipt, to: :pull_request_service
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -172,7 +172,7 @@ class User < ApplicationRecord
 
   def bonus_score
     score = waiting_or_eligible_pull_requests_count - 4
-    score < 0 ? 0 : score
+    [score, 0].max
   end
 
   delegate :scoring_pull_requests, :non_scoring_pull_requests,

--- a/app/presenters/profile_page_presenter.rb
+++ b/app/presenters/profile_page_presenter.rb
@@ -56,7 +56,7 @@ class ProfilePagePresenter
   end
 
   def bonus_score
-    (@user.eligible_pull_requests_count || 0) - @user.score
+    @user.bonus_score || 0
   end
 
   def name


### PR DESCRIPTION
# Description

Fixes #628. Include waiting PRs in the calculated bonus score, to match the main score calculation.

# Test process

Have more than four waiting PRs. Score shows as 4/4, extra waiting PRs show up in the bonus count below.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
