### PR TITLE
Fixed profile page info panel on dark mode. Test required

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -712,6 +712,14 @@ body.dark {
   background-color: $dark-backgroundColor !important;
   color: $dark-textColor !important;
 
+  .info-pane h2, .info-pane h3 {
+    color: $dark-backgroundColor !important;
+  }
+
+  .info-pane p {
+    color: $dark-backgroundColor !important;
+  }
+
   h1,
   h2,
   h3 {


### PR DESCRIPTION
# Description
I saw the info panel on the profile page has some read/accessibility issues on dark mode. Here we have the current appearance:

![image](https://user-images.githubusercontent.com/1944438/95256839-aa5c8600-0823-11eb-9f12-f0ff5bdf6cc6.png)
 
And here, the fixed version:

![image](https://user-images.githubusercontent.com/1944438/95256894-be07ec80-0823-11eb-8f30-3ab86c2d5b12.png)

It's a simple CSS change.

# Test process
- [ ] I cannot test this change on my current laptop, I need some help to test it.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
