### PR TITLE
Disable waiting transition after Hf ends

### DIFF
--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 class PullRequest < ApplicationRecord
   attr_reader :github_pull_request
 
@@ -136,3 +137,4 @@ class PullRequest < ApplicationRecord
     pr
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -42,7 +42,8 @@ class PullRequest < ApplicationRecord
     event :waiting do
       transition all - %i[eligible] => :waiting,
                  if: lambda { |pr|
-                       !pr.passed_review_period? &&
+                       !pr.hacktoberfest_ended? &&
+                         !pr.passed_review_period? &&
                          !pr.spammy? &&
                          !pr.labelled_invalid? &&
                          pr.in_topic_repo? &&
@@ -112,6 +113,10 @@ class PullRequest < ApplicationRecord
     return true if created_at <= Hacktoberfest.rules_date
 
     merged? || approved? || labelled_accepted?
+  end
+
+  def hacktoberfest_ended?
+    Hacktoberfest.end_date.past?
   end
 
   def github_id

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -411,6 +411,37 @@ RSpec.describe PullRequest, type: :model do
         after { travel_back }
       end
     end
+
+    context 'Pull request is not approved initially' do
+      let(:pr) { pr_helper(UNMERGED_PR) }
+
+      it 'is in the not_accepted state initially' do
+        expect(pr.state).to eq('not_accepted')
+      end
+
+      it 'has no set waiting_since' do
+        expect(pr.waiting_since).to be_nil
+      end
+
+      context 'Pull request is merged after the end of Hacktoberfest' do
+        before do
+          travel_to Time.zone.parse(ENV['END_DATE']) + 1.day
+
+          stub_helper(pr, IMMATURE_PR, 'id' => pr.github_id)
+          pr.check_state
+        end
+
+        it 'is left in the not_accepted state' do
+          expect(pr.state).to eq('not_accepted')
+        end
+
+        it 'has no set waiting_since' do
+          expect(pr.waiting_since).to be_nil
+        end
+
+        after { travel_back }
+      end
+    end
   end
 
   describe '#eligible' do


### PR DESCRIPTION
# Description

As we have moved to require PRs be merged this year, instead of just created, a PR could be merged after the end of October and we would consider this, transitioning it to waiting and starting the timer.

To prevent this, a check was added to the waiting transition to ensure that Hf has not yet ended. A spec has also be added to ensure this behaviour remains correct.

# Test process

- Create a PR during Hacktoberfest
- Merge the PR after Hacktoberfest
- Ensure the PR does not transition to waiting

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
