### PR TITLE
Use yyyy/mm/dd date format

### DIFF
--- a/app/views/pages/hacktoberfest_update.html.erb
+++ b/app/views/pages/hacktoberfest_update.html.erb
@@ -3,9 +3,9 @@
 
     <h1 class="title">UPDATED: An update on efforts to reduce spam with Hacktoberfest: introducing maintainer opt-in and more.</h1>
 
-    <p><em>Posted at 10/03/2020 02:30 UTC</em></p>
+    <p><em>Posted at 2020/10/03 02:30 UTC</em></p>
 
-    <p><i>Updated (10/05/2020 15:00 UTC): Individual pull requests can also be directly opted-in to Hacktoberfest with the ‘hacktoberfest-accepted’ label, on any public GitHub repository, without the need for the ‘hacktoberfest’ repository topic.</i></p>
+    <p><i>Updated (2020/10/05 15:00 UTC): Individual pull requests can also be directly opted-in to Hacktoberfest with the ‘hacktoberfest-accepted’ label, on any public GitHub repository, without the need for the ‘hacktoberfest’ repository topic.</i></p>
 
     <p>Thank you to everyone who has reached out with ideas and suggestions to help Hacktoberfest live its values of celebrating and fostering the open source community.</p>
 
@@ -57,7 +57,7 @@
 
     <h1 class="title">Shared commitment to reducing spam with Hacktoberfest</h1>
     
-    <p><em>Updated at 10/01/2020 13:00 UTC</em></p>
+    <p><em>Updated at 2020/10/01 13:00 UTC</em></p>
 
     <p>Since the start of Hacktoberfest 2020, open source maintainers have experienced a noticeable uptick in spammy pull requests originating from Hacktoberfest participants. As of 2pm PST on October 1, <em>at least</em> 4% of pull requests from Hacktoberfest participants have been marked ‘invalid’ or ‘spam.’</p>
 
@@ -76,7 +76,7 @@
     <ol>
       <li>
         <s>For maintainers, we’re building on an existing idea and doubling down on an <strong>excluded repository list</strong> for Hacktoberfest. If you don’t want pull requests to your repositories counted toward Hacktoberfest, send us the info in an email to <a href="mailto:hacktoberfestmaintainers@digitalocean.com">hacktoberfestmaintainers@digitalocean.com</a>.</s>
-        <i>Updated (10/03/2020 00:00 UTC): We have now made Hacktoberfest opt-in, please see our updated response above.</i>
+        <i>Updated (2020/10/03 00:00 UTC): We have now made Hacktoberfest opt-in, please see our updated response above.</i>
       </li>
       <li>We are also implementing a <strong>banning system</strong> that reviews and bans users with with too many flagged PR’s. This can result in exclusion from all future Hacktoberfests, not just this one.</li>
       <li>This year, we’re also <strong>extending the validation period</strong> from one week to 14 days. This will give maintainers more time to review pull requests before contributors earn their shirts.</li>


### PR DESCRIPTION
# Description

To avoid confusion for international folks, use the `yyyy/mm/dd` date format instead of the very american-centric `mm/dd/yyyy` date format.

# Test process

N/A

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
