### PR TITLE
Add rake task to backfill acceptance

### DIFF
--- a/lib/tasks/backfill_acceptance.rake
+++ b/lib/tasks/backfill_acceptance.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+namespace :users do
+  desc 'Backfill all existing users for acceptance'
+  task backfill_acceptance: :environment do
+    User.where.not(state: 'new').find_each do |user|
+      user.quality_acceptance = true
+      user.disqualify_acceptance = true
+
+      # Fail-fast: if this errors,
+      #  we have a broken user and should know about it
+      user.save!
+    end
+  end
+end


### PR DESCRIPTION
# Description

When we added the new registration acceptance columns, they were defaulted to false without backfilling existing users. This means that they fail validation and cannot transition state.

This rake task should ensure that every user that has signed up has the new acceptance columns set to true.

# Test process

- Authenticate as a user but do not sign up
- Update the user to have `terms_acceptance=true` and `state=registered` in the database
- Observe the user has not accepted the quality/disqualify acceptance
- Run the rake taks `rake users:backfill_acceptance`
- Observe the user has now accepted the quality/disqualify acceptance 

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
