### PR TITLE
Add rescue to rake and add force rake

### DIFF
--- a/lib/tasks/backfill_acceptance.rake
+++ b/lib/tasks/backfill_acceptance.rake
@@ -7,9 +7,23 @@ namespace :users do
       user.quality_acceptance = true
       user.disqualify_acceptance = true
 
-      # Fail-fast: if this errors,
-      #  we have a broken user and should know about it
-      user.save!
+      begin
+        user.save!
+      rescue StandardError => e
+        # Log any errors to catch any broken users
+        p user
+        p e
+      end
+    end
+  end
+
+  desc 'Forcefully backfill all existing users for acceptance'
+  task force_backfill_acceptance: :environment do
+    User.where.not(state: 'new').find_each do |user|
+      user.quality_acceptance = true
+      user.disqualify_acceptance = true
+      # Skip validation, just set it for everyone
+      user.save!(validate: false)
     end
   end
 end


### PR DESCRIPTION
# Description

In the event we have a bad user, the rake would fail. This adds rescue logic around the save, so we are made aware of broken users but it doesn't fail. We then have a second rake to set the values for everyone.

```
docker-compose exec app bundle exec rake users:backfill_acceptance

#<User id: 2, name: "test", email: "test@test.com", uid: -1, provider_token: "SNIP", created_at: "2020-10-07 14:45:10", updated_at: "2020-10-07 16:00:13", provider: "github", terms_acceptance: true, digitalocean_marketing_emails: false, state: "registered", receipt: nil, intel_marketing_emails: false, dev_marketing_emails: false, category: "participant", country: nil, quality_acceptance: true, disqualify_acceptance: true>
#<GithubPullRequestService::UserNotFoundOnGithubError: GithubPullRequestService::UserNotFoundOnGithubError>

Exit 0

docker-compose exec app bundle exec rake users:force_backfill_acceptance

Exit 0
```

# Test process

Running the rakes works.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
