### PR TITLE
Fix winning receipt logic

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -166,13 +166,11 @@ class User < ApplicationRecord
   end
 
   def score
-    score = waiting_or_eligible_pull_requests_count
-    score > 4 ? 4 : score
+    [4, waiting_or_eligible_pull_requests_count].min
   end
 
   def bonus_score
-    score = waiting_or_eligible_pull_requests_count - 4
-    [score, 0].max
+    [0, waiting_or_eligible_pull_requests_count - 4].max
   end
 
   delegate :scoring_pull_requests, :non_scoring_pull_requests,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -173,8 +173,8 @@ class User < ApplicationRecord
     [0, waiting_or_eligible_pull_requests_count - 4].max
   end
 
-  delegate :scoring_pull_requests, :non_scoring_pull_requests,
-           :scoring_pull_requests_receipt, to: :pull_request_service
+  delegate :scoring_pull_requests, :scoring_pull_requests_receipt,
+           to: :pull_request_service
 
   def hacktoberfest_ended?
     Hacktoberfest.end_date.past?

--- a/app/presenters/profile_page_presenter.rb
+++ b/app/presenters/profile_page_presenter.rb
@@ -28,10 +28,14 @@ class ProfilePagePresenter
   end
 
   def scoring_pull_requests
-    if @user.receipt
-      persisted_winning_pull_requests
-    else
-      @user.scoring_pull_requests
+    # If the user has won, show their winning PRs
+    return persisted_winning_pull_requests if @user.receipt
+
+    # Show all the PRs until we reach four winning/waiting
+    counter = 0
+    @user.pull_requests.take_while do |pr|
+      counter += 1 if pr.eligible? || pr.waiting?
+      counter <= 4
     end
   end
 
@@ -44,7 +48,9 @@ class ProfilePagePresenter
   end
 
   def non_scoring_pull_requests
-    @user.non_scoring_pull_requests
+    # Show all the PRs not in the scoring section
+    scoring = scoring_pull_requests.map(&:github_id)
+    @user.pull_requests.reject { |pr| scoring.include?(pr.github_id) }
   end
 
   def score

--- a/app/services/pull_request_service.rb
+++ b/app/services/pull_request_service.rb
@@ -44,21 +44,13 @@ class PullRequestService
   end
 
   def scoring_pull_requests
-    counter = 0
-    all.take_while do |pr|
-      counter += 1 if pr.eligible?
-      counter <= 4
-    end
+    eligible_prs.first(4)
   end
 
   def scoring_pull_requests_receipt
     scoring_pull_requests.map do |pr|
       pr.github_pull_request.graphql_hash
     end
-  end
-
-  def non_scoring_pull_requests
-    all.drop(scoring_pull_requests.count)
   end
 
   protected

--- a/spec/services/pull_request_service_spec.rb
+++ b/spec/services/pull_request_service_spec.rb
@@ -102,22 +102,6 @@ RSpec.describe PullRequestService do
     end
   end
 
-  describe '#non_scoring_pull_requests' do
-    context 'a user with more than 4 eligible pull requests' do
-      before { stub_helper(PR_DATA[:valid_array]) }
-      it 'returns the all PRs minus scoring_pull_requests' do
-        expect(pr_service.non_scoring_pull_requests.count).to eq(1)
-      end
-    end
-
-    context 'a user with with 2 eligible pull requests' do
-      before { stub_helper(PR_DATA[:valid_array].first(2)) }
-      it 'returns an empty array' do
-        expect(pr_service.non_scoring_pull_requests.count).to eq(0)
-      end
-    end
-  end
-
   def stub_helper(arr_type)
     PullRequest.delete_all
     allow(pr_service)


### PR DESCRIPTION
# Description

Fixes the logic used for what we consider a scoring pull request in the user. When a user wins, we store a frozen receipt on their winning PRs. This has now been updated to just freeze their first four eligible PRs, so they will always display on the profile. No other PRs are frozen and will show based on their current state on GitHub.

# Test process

- Register with a user
- Have PRs such that there is at least one waiting and one invalid PR intermixed with four other waiting PRs
- Ensure the profile renders all the PRs in the expected state
- Set four of the waiting PRs to be eligible in the database
- Reload the profile and observe that the four eligible PRs are hoisted to the top
- The remaining waiting and invalid PR are shown below
- Ensure that the four eligible PRs have been stored in the user receipt in the database

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
