### PR TITLE
feat: Add lint workflow for ERB files.

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,9 @@
+---
+    linters:
+      ErbSafety:
+        enabled: true
+      Rubocop:
+        enabled: true
+        rubocop_config:
+          inherit_from:
+            - .rubocop.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,3 +19,9 @@ jobs:
         gem install bundler dotenv
         bundle install --jobs 4 --retry 3
         bundle exec rubocop
+    - name: Linting with ERB Lint
+      run: |
+        sudo apt-get install libpq-dev
+        gem install bundler dotenv
+        bundle install --jobs 4 --retry 3
+        bundle exec erblint

--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,8 @@ group :development, :test do
 
   gem 'dotenv-rails'
 
+  gem 'erb_lint'
+
   gem 'factory_bot_rails'
 
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,14 @@ GEM
       net-http-persistent (>= 2.9)
     arel (9.0.0)
     ast (2.4.0)
+    better_html (1.0.15)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.6)
+      parser (>= 2.4)
+      smart_properties
     bindex (0.8.1)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
@@ -108,6 +116,13 @@ GEM
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
     e2mmap (0.1.0)
+    erb_lint (0.0.30)
+      activesupport
+      better_html (~> 1.0.7)
+      html_tokenizer
+      rainbow
+      rubocop (~> 0.51)
+      smart_properties
     erubi (1.8.0)
     et-orbi (1.2.4)
       tzinfo
@@ -148,6 +163,7 @@ GEM
     hashie (3.6.0)
     health_check (3.0.0)
       railties (>= 5.0)
+    html_tokenizer (0.0.7)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     i18n_data (0.10.0)
@@ -322,6 +338,7 @@ GEM
       thwait
       tilt (>= 1.4.0)
     sixarm_ruby_unaccent (1.2.0)
+    smart_properties (1.15.0)
     sort_alphabetical (1.1.0)
       unicode_utils (>= 1.2.2)
     spring (2.1.0)
@@ -393,6 +410,7 @@ DEPENDENCIES
   country_select (~> 4.0)
   dalli (~> 2.7)
   dotenv-rails
+  erb_lint
   factory_bot_rails
   faraday
   faraday_middleware


### PR DESCRIPTION
# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR adds a `.erb` lint step to the `lint` workflow, using the `erb-lint` gem. Currently I use the default configuration, which *generates 1122 linter errors*. I've left this PR in a draft state to get feedback on the preferred ruleset before pulling in fixes for the errors. 

The default ruleset is:
![image](https://user-images.githubusercontent.com/63889819/95508831-73dc5380-0968-11eb-82d3-029c2394f4a4.png)

Each rule can be enabled/disabled individually, so I am hoping for guidance on which rules should be applied.

# Test process
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

I ran the lint command that I added to the `lint.yml` workflow file manually, and verified that it hit the intended files and yielded results. I also verified that the `script/tests` still worked correctly.

The commands were all run in an Ubuntu shell for the WSL service, because Windows doesn't play well with Ruby natively.

- [ ] Test A
- [ ] Test B

# Requirements to merge
<!--
Ensure your pull request meets all the requirements for merging. Place an `x` in each box to indicate that your pull request meets that requirement.
-->
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
