### PR TITLE
Rephrase 'PR counts logic' to match what's actually happening

### DIFF
--- a/app/views/pages/details.html.erb
+++ b/app/views/pages/details.html.erb
@@ -105,18 +105,7 @@
         not in line with the values of Hacktoberfest or the project’s code of conduct, you will be ineligible to
         participate. This year, the first 70,000 participants can earn a T-shirt or plant a tree.</p>
       
-      <p>To put the rules in a form consistent with the spirit of Hacktoberfest:</p>
-      <blockquote>
-        PRs count if:
-        <br/>Submitted during the month of October AND
-        <br/>Submitted in a public repo AND (
-        <br/>&nbsp;&nbsp;The PR is labelled as <code>hacktoberfest-accepted</code> by a maintainer OR
-        <br/>&nbsp;&nbsp;Submitted in a repo with the <code>hacktoberfest</code> topic AND (
-        <br/>&nbsp;&nbsp;&nbsp;&nbsp;The PR is merged OR
-        <br/>&nbsp;&nbsp;&nbsp;&nbsp;The PR has been approved
-        <br/>&nbsp;&nbsp;)
-        <br/>)
-      </blockquote>
+      <%= render 'shared/rules' %>
     </section>
 
     <section class="quality-standards">

--- a/app/views/pages/hacktoberfest_update.html.erb
+++ b/app/views/pages/hacktoberfest_update.html.erb
@@ -15,19 +15,7 @@
     
     <p>We will honor all valid pull requests prior to this change, and as of October 3, 2020 at 12:00:00 UTC – and October 3 in <em>all</em> time zones – pull requests will only count toward earning a T-shirt or planting a tree if they are labeled as ‘hacktoberfest-accepted’ by a maintainer, or submitted in a repository classified with the <a href="https://github.com/topics/hacktoberfest">‘hacktoberfest’ topic</a>. Pull requests in repositories with the ‘hacktoberfest’ topic will also need to be merged, approved by a maintainer, or labeled as ‘hacktoberfest-accepted’ in order to qualify. The deadline for completions, merging, labeling, and approving is November 1.</p>
 
-    <p>To put the rules in a form consistent with the spirit of Hacktoberfest:</p>
-
-    <blockquote>
-      PRs count if:
-      <br/>Submitted during the month of October AND
-      <br/>Submitted in a public repo AND (
-      <br/>&nbsp;&nbsp;The PR is labelled as <code>hacktoberfest-accepted</code> by a maintainer OR
-      <br/>&nbsp;&nbsp;Submitted in a repo with the <code>hacktoberfest</code> topic AND (
-      <br/>&nbsp;&nbsp;&nbsp;&nbsp;The PR is merged OR
-      <br/>&nbsp;&nbsp;&nbsp;&nbsp;The PR has been approved
-      <br/>&nbsp;&nbsp;)
-      <br/>)
-    </blockquote>
+    <%= render 'shared/rules' %>
 
     <p><strong>A note to maintainers:</strong> Due to this change, you no longer need to opt out of Hacktoberfest.  Instead, we invite you to <a href="https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/classifying-your-repository-with-topics">classify your repository with the hacktoberfest topic</a> and <a href="https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/applying-labels-to-issues-and-pull-requests">apply hacktoberfest-accepted labels to pull requests</a> you want to accept. We’ve included a few gifs below to show you how simple this can be.</p>
     

--- a/app/views/shared/_rules.html.erb
+++ b/app/views/shared/_rules.html.erb
@@ -1,0 +1,12 @@
+<p>To put the rules in a form consistent with the spirit of Hacktoberfest:</p>
+
+<blockquote>
+  PRs count if:
+  <br/>Submitted during the month of October AND
+  <br/>Submitted in a public repo AND (
+  <br/>&nbsp;&nbsp;The PR is labelled as <code>hacktoberfest-accepted</code> by a maintainer OR
+  <br/>&nbsp;&nbsp;Submitted in a repo with the <code>hacktoberfest</code> topic OR
+  <br/>&nbsp;&nbsp;The PR is merged OR
+  <br/>&nbsp;&nbsp;The PR has been approved
+  <br/>)
+</blockquote>


### PR DESCRIPTION
# Description

I started by [tweeting this](https://twitter.com/davidstosik/status/1314423522672824321), but then realised it's part of a code base I can submit a PR for! 💡 

I have the feeling that the logic described on the [Hacktoberfest update](https://hacktoberfest.digitalocean.com/hacktoberfest-update), and on the [details](https://hacktoberfest.digitalocean.com/details) page does not match what is described on my profile page (quoted below), or what I am experiencing with my own PRs.

Here's what I read on my profile page (emphasis mine):

> # Legend
>
> ## :clock4: In Review
>
> Your PR has been accepted by a maintainer and is currently within the review period, which lasts for fourteen days.
>
> ## :question: Pending
>
> Your PR has not yet been accepted by a maintainer. **A maintainer can accept your PR by merging it, adding the "hacktoberfest-accepted" label to it, or approving it.**
>
> ## :x: Invalid
>
> Your PR has been labeled as "invalid" or "spam" by a maintainer and won't count toward winning Hacktoberfest.
>
> ## :exclamation: Ineligible Repository
>
> Your PR was submitted to a repository that is not participating in Hacktoberfest. **Maintainers of the repository can add the "hacktoberfest" topic to their repository if they wish to participate. Alternatively, an individual PR can be opted-in with a maintainer adding the "hacktoberfest-accepted" label to the PR.**
>
> ## :white_check_mark: Accepted
>
> Good job! Your PR has passed the review period and counts toward completing the Hacktoberfest challenge!


I assumed that the behavior described on my profile page is the intended behavior (as this is what I observe with my PRs, see below), and that the static HTML with the described logic was wrong. I might be mistaken, so please let me know.


# Test process

[I have 4 PRs](https://github.com/zipmark/rspec_api_documentation/pulls?q=is%3Apr+is%3Aclosed+author%3Adavidstosik+created%3A%3E%3D2020-10-01), which I submitted before the changes to the rules (don't kno if this matters).

- The PRs have been merged.
- The PRs are not tagged with `hacktoberfest-approved` (at time of writing).
- The repository does not have the `hacktoberfest` topic (at time of writing).
- And yet, the 4 PRs are all marked as ":clock4: **In Review**".

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
