### PR TITLE
Rectified extra spacing in paragraph (bug)

### DIFF
--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -25,7 +25,11 @@
       -webkit-border-radius: 8px;
       -khtml-border-radius: 8px;
       border-radius: 8px;
-
+      
+      .p-margin{
+        margin-top: 0;
+      }
+      
       p,
       h1,
       h3,

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -97,7 +97,7 @@
     </div>
 
     <div class="main-content-wrapper">
-      <p>Have you seen a repository that you don't think aligns with the <%= link_to "Hacktoberfest values", details_path %>? Please <%= link_to "report it to us", report_path %> so we can take a look.</p>
+      <p class="p-margin">Have you seen a repository that you don't think aligns with the <%= link_to "Hacktoberfest values", details_path %>? Please <%= link_to "report it to us", report_path %> so we can take a look.</p>
     </div>
   </div>
 


### PR DESCRIPTION
# Description
Rectified the extra margin on the paragraph in the profile page.
Wrt. issue : #679 
# Test process
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->
Changes done in the profile.scss file where margin of paragraph tag was put 0, which rectified the issue.
The reload of the page shows the changes.
### Before
![Before](https://user-images.githubusercontent.com/20267705/96002729-1445e280-0e57-11eb-9e08-bffd2c7721da.png)

### After
![After](https://user-images.githubusercontent.com/20267705/96002753-19a32d00-0e57-11eb-9c60-73d2355406bf.png)

# Requirements to merge
<!--
Ensure your pull request meets all the requirements for merging. Place an `x` in each box to indicate that your pull request meets that requirement.
-->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
