### PR TITLE
Show the first four eligible PRs by maturity rather than submission

### DIFF
--- a/app/services/pull_request_service.rb
+++ b/app/services/pull_request_service.rb
@@ -44,7 +44,7 @@ class PullRequestService
   end
 
   def scoring_pull_requests
-    eligible_prs.first(4)
+    eligible_prs.sort_by { |pr| [pr.:eligible?, pr.waiting_since]}.first(4)
   end
 
   def scoring_pull_requests_receipt


### PR DESCRIPTION
Due to retrospective tagging in non-topic repos, submission is not always equal to maturity.

# Description
As per the title.

# Test process
None so far, need to add an array check to the spec to ensure the result is sorted correctly.

# Requirements to merge
<!--
Ensure your pull request meets all the requirements for merging. Place an `x` in each box to indicate that your pull request meets that requirement.
-->
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
