### PR TITLE
Removed duplicated word from the update page

### DIFF
--- a/app/views/pages/hacktoberfest_update.html.erb
+++ b/app/views/pages/hacktoberfest_update.html.erb
@@ -78,7 +78,7 @@
         <s>For maintainers, we’re building on an existing idea and doubling down on an <strong>excluded repository list</strong> for Hacktoberfest. If you don’t want pull requests to your repositories counted toward Hacktoberfest, send us the info in an email to <a href="mailto:hacktoberfestmaintainers@digitalocean.com">hacktoberfestmaintainers@digitalocean.com</a>.</s>
         <i>Updated (2020/10/03 00:00 UTC): We have now made Hacktoberfest opt-in, please see our updated response above.</i>
       </li>
-      <li>We are also implementing a <strong>banning system</strong> that reviews and bans users with with too many flagged PR’s. This can result in exclusion from all future Hacktoberfests, not just this one.</li>
+      <li>We are also implementing a <strong>banning system</strong> that reviews and bans users with too many flagged PR’s. This can result in exclusion from all future Hacktoberfests, not just this one.</li>
       <li>This year, we’re also <strong>extending the validation period</strong> from one week to 14 days. This will give maintainers more time to review pull requests before contributors earn their shirts.</li>
     </ol>
     


### PR DESCRIPTION
# Description
This PR just removes a duplicated word from the [Update page](https://hacktoberfest.digitalocean.com/hacktoberfest-update).

> (...) that reviews and bans users **with with** too many flagged PR’s (...)

**Please note** that this is not an attempt to get a PR for Hacktoberfest. 
I just wanted to correct the sentence on the update page. 
Feel free to exclude this PR from Hacktoberfest by labeling it accordingly :) 

# Test process
(**not necessary**)

# Requirements to merge
<!--
Ensure your pull request meets all the requirements for merging. Place an `x` in each box to indicate that your pull request meets that requirement.
-->
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
