### PR TITLE
Added Open button to the prize link

### DIFF
--- a/app/views/users/show/_display_coupons.html.erb
+++ b/app/views/users/show/_display_coupons.html.erb
@@ -18,6 +18,7 @@
         <label for="winner-code" class="is-sr-only">Prize URL</label>
         <input type="text" id="winner-code" value="https://stores.kotisdesign.com/hacktoberfest/<%= code %>" readonly/>
         <button class="button-static code-button" id="copy-winner-code" onclick="copyCodeToClipboard()">Copy</button>
+        <a href="https://stores.kotisdesign.com/hacktoberfest/<%= code %>" target="_blank" class="button-static code-button">Open</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Description
Added an open button to the prize link so it is easier to use.

Desktop:
![obrazek](https://user-images.githubusercontent.com/53915302/96564218-2b575b00-12c3-11eb-837b-724ab5d6c41a.png)

Phone (iPhone Xs):
![obrazek](https://user-images.githubusercontent.com/53915302/96564277-3dd19480-12c3-11eb-8098-d738ee4524d2.png)


# Requirements to merge
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
