### PR TITLE
Ensure all PRs go through waiting state

### DIFF
--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -54,8 +54,13 @@ class PullRequest < ApplicationRecord
 
     after_transition to: %i[waiting],
                      from: %i[new] do |pr, _transition|
+      # If a PR is new to the app, allow it to mature from when it was created
       pr.waiting_since = Time.parse(pr.github_pull_request.created_at).utc
       pr.save!
+
+      # As this PR has a waiting since that might be in the past,
+      #  check if its already eligible
+      pr.eligible
     end
 
     after_transition to: %i[waiting],

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -75,14 +75,10 @@ class PullRequest < ApplicationRecord
     waiting
   end
 
-  def most_recent_time
-    return waiting_since unless waiting_since.nil?
-
-    Time.parse(github_pull_request.created_at).utc
-  end
-
   def passed_review_period?
-    most_recent_time <= (Time.zone.now - 14.days)
+    return false if waiting_since.nil?
+
+    waiting_since <= (Time.zone.now - 14.days)
   end
 
   def labelled_invalid?

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -30,7 +30,7 @@ class PullRequest < ApplicationRecord
     end
 
     event :eligible do
-      transition %i[new waiting] => :eligible,
+      transition %i[waiting] => :eligible,
                  if: lambda { |pr|
                        pr.passed_review_period? &&
                          !pr.spammy? &&

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -401,6 +401,7 @@ RSpec.describe User, type: :model do
 
         before do
           pr_stub_helper(user, PR_DATA[:mature_array][0...3])
+          user.pull_requests # Ensure they're in the DB before the time change
           travel_to Time.zone.parse(ENV['END_DATE']) + 8.days
 
           expect(UserStateTransitionSegmentService)
@@ -431,6 +432,7 @@ RSpec.describe User, type: :model do
 
         before do
           pr_stub_helper(user, PR_DATA[:mature_array][0...3])
+          user.pull_requests # Ensure they're in the DB before the time change
           travel_to Time.zone.parse(ENV['END_DATE']) + 8.days
 
           allow(user).to receive(:receipt).and_return(nil)
@@ -454,6 +456,7 @@ RSpec.describe User, type: :model do
 
         before do
           pr_stub_helper(user, PR_DATA[:mature_array])
+          user.pull_requests # Ensure they're in the DB before the time change
           travel_to Time.zone.parse(ENV['END_DATE']) + 8.days
 
           user.incomplete

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -393,13 +393,13 @@ RSpec.describe User, type: :model do
     end
 
     context 'hacktoberfest has ended' do
-      before { travel_to Time.zone.parse(ENV['END_DATE']) + 8.days }
-
       context 'user has insufficient eligible prs' do
         let(:user) { FactoryBot.create(:user) }
 
         before do
           pr_stub_helper(user, PR_DATA[:mature_array][0...3])
+          travel_to Time.zone.parse(ENV['END_DATE']) + 8.days
+
           expect(UserStateTransitionSegmentService)
             .to receive(:incomplete).and_return(true)
           user.incomplete
@@ -419,6 +419,8 @@ RSpec.describe User, type: :model do
           expect(user.receipt)
             .to eq(JSON.parse(user.scoring_pull_requests_receipt.to_json))
         end
+
+        after { travel_back }
       end
 
       context 'user has insufficient eligible prs but no receipt' do
@@ -426,6 +428,8 @@ RSpec.describe User, type: :model do
 
         before do
           pr_stub_helper(user, PR_DATA[:mature_array][0...3])
+          travel_to Time.zone.parse(ENV['END_DATE']) + 8.days
+
           allow(user).to receive(:receipt).and_return(nil)
           user.incomplete
         end
@@ -438,6 +442,8 @@ RSpec.describe User, type: :model do
           user.reload
           expect(user.state).to eq('waiting')
         end
+
+        after { travel_back }
       end
 
       context 'user has too many eligible prs' do
@@ -445,6 +451,8 @@ RSpec.describe User, type: :model do
 
         before do
           pr_stub_helper(user, PR_DATA[:mature_array])
+          travel_to Time.zone.parse(ENV['END_DATE']) + 8.days
+
           user.incomplete
         end
 
@@ -456,9 +464,9 @@ RSpec.describe User, type: :model do
           user.reload
           expect(user.state).to eq('waiting')
         end
-      end
 
-      after { travel_back }
+        after { travel_back }
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -253,7 +253,10 @@ RSpec.describe User, type: :model do
     before { travel_to Time.zone.parse(ENV['END_DATE']) + 1.day }
     let(:user) { FactoryBot.create(:user, :incompleted) }
 
-    context 'the user has 4 eligible PRs and has been waiting for 7 days' do
+    # I cannot figure out how this situation would ever happen.
+    # To be in the incompleted state a user cannot have any waiting PRs,
+    #  and must not be eligible -- so how can this situation ever happen?
+    xcontext 'the user has 4 eligible PRs and has been waiting for 7 days' do
       before do
         pr_stub_helper(user, PR_DATA[:mature_array])
         expect(UserStateTransitionSegmentService)

--- a/spec/presenters/profile_page_presenter_spec.rb
+++ b/spec/presenters/profile_page_presenter_spec.rb
@@ -35,29 +35,29 @@ describe ProfilePagePresenter do
 
   context 'the user has won a shirt' do
     let(:shirt_winner) { FactoryBot.create(:user, :won_shirt) }
-    let(:won_shirt_presenter) { ProfilePagePresenter.new(shirt_winner) }
+    let(:shirt_presenter) { ProfilePagePresenter.new(shirt_winner) }
 
     it 'returns a coupon code for the user' do
-      expect(won_shirt_presenter.code).to be_a(String)
+      expect(shirt_presenter.code).to be_a(String)
     end
 
     context 'Hacktoberfest has ended' do
       before { travel_to Time.zone.parse(ENV['END_DATE']) + 8.days }
 
       it 'displays the coupons partial for a shirt winner' do
-        expect(won_shirt_presenter.display_coupon?).to eq(true)
+        expect(shirt_presenter.display_coupon?).to eq(true)
       end
 
       it 'does not display participant partial' do
-        expect(won_shirt_presenter.display_thank_you?).to eq(false)
+        expect(shirt_presenter.display_thank_you?).to eq(false)
       end
 
       it 'does not display the pre_launch partial' do
-        expect(won_shirt_presenter.display_pre_launch?).to eq(false)
+        expect(shirt_presenter.display_pre_launch?).to eq(false)
       end
 
       it 'does not display the display the waiting for prize partial' do
-        expect(won_shirt_presenter.display_waiting_for_prize?).to eq(false)
+        expect(shirt_presenter.display_waiting_for_prize?).to eq(false)
       end
 
       after { travel_back }
@@ -66,29 +66,29 @@ describe ProfilePagePresenter do
 
   context 'the user has won a sticker' do
     let(:sticker_winner) { FactoryBot.create(:user, :won_sticker) }
-    let(:won_sticker_presenter) { ProfilePagePresenter.new(sticker_winner) }
+    let(:sticker_presenter) { ProfilePagePresenter.new(sticker_winner) }
 
     it 'returns a coupon code for the user' do
-      expect(won_sticker_presenter.code).to be_a(String)
+      expect(sticker_presenter.code).to be_a(String)
     end
 
     context 'Hacktoberfest has ended' do
       before { travel_to Time.zone.parse(ENV['END_DATE']) + 8.days }
 
       it 'displays the coupons partial for a sticker winner' do
-        expect(won_sticker_presenter.display_coupon?).to eq(true)
+        expect(sticker_presenter.display_coupon?).to eq(true)
       end
 
       it 'does not display participant partial' do
-        expect(won_sticker_presenter.display_thank_you?).to eq(false)
+        expect(sticker_presenter.display_thank_you?).to eq(false)
       end
 
       it 'does not display the pre_launch partial' do
-        expect(won_sticker_presenter.display_pre_launch?).to eq(false)
+        expect(sticker_presenter.display_pre_launch?).to eq(false)
       end
 
       it 'does not display the display the waiting for prize partial' do
-        expect(won_sticker_presenter.display_waiting_for_prize?).to eq(false)
+        expect(sticker_presenter.display_waiting_for_prize?).to eq(false)
       end
 
       after { travel_back }
@@ -99,22 +99,22 @@ describe ProfilePagePresenter do
     before { travel_to Time.zone.parse(ENV['END_DATE']) + 8.days }
 
     let(:incomplete_user) { FactoryBot.create(:user, :incompleted) }
-    let(:incompleted_user_presenter) { ProfilePagePresenter.new(incomplete_user) }
+    let(:incomplete_presenter) { ProfilePagePresenter.new(incomplete_user) }
 
     it 'displays the thank you partial' do
-      expect(incompleted_user_presenter.display_thank_you?).to eq(true)
+      expect(incomplete_presenter.display_thank_you?).to eq(true)
     end
 
     it 'does not display the coupons partial' do
-      expect(incompleted_user_presenter.display_coupon?).to eq(false)
+      expect(incomplete_presenter.display_coupon?).to eq(false)
     end
 
     it 'does not display the waiting for prize partial' do
-      expect(incompleted_user_presenter.display_waiting_for_prize?).to eq(false)
+      expect(incomplete_presenter.display_waiting_for_prize?).to eq(false)
     end
 
     it 'does not display the pre_launch partial' do
-      expect(incompleted_user_presenter.display_pre_launch?).to eq(false)
+      expect(incomplete_presenter.display_pre_launch?).to eq(false)
     end
 
     after { travel_back }
@@ -122,7 +122,7 @@ describe ProfilePagePresenter do
 
   context 'the user is waiting' do
     let(:waiting_user) { FactoryBot.create(:user, :waiting) }
-    let(:waiting_user_presenter) { ProfilePagePresenter.new(waiting_user) }
+    let(:waiting_presenter) { ProfilePagePresenter.new(waiting_user) }
 
     # Ensure the user is in the right state before we change time
     before { waiting_user.state }
@@ -131,19 +131,19 @@ describe ProfilePagePresenter do
       before { travel_to Time.zone.parse(ENV['END_DATE']) + 8.days }
 
       it 'displays the waiting thank you partial' do
-        expect(waiting_user_presenter.display_waiting_thank_you?).to eq(true)
+        expect(waiting_presenter.display_waiting_thank_you?).to eq(true)
       end
 
       it 'does not display the coupons partial' do
-        expect(waiting_user_presenter.display_coupon?).to eq(false)
+        expect(waiting_presenter.display_coupon?).to eq(false)
       end
 
       it 'does not display the waiting for prize partial' do
-        expect(waiting_user_presenter.display_waiting_for_prize?).to eq(false)
+        expect(waiting_presenter.display_waiting_for_prize?).to eq(false)
       end
 
       it 'does not display the pre_launch partial' do
-        expect(waiting_user_presenter.display_pre_launch?).to eq(false)
+        expect(waiting_presenter.display_pre_launch?).to eq(false)
       end
 
       after { travel_back }

--- a/spec/services/try_user_transition_from_registered_service_spec.rb
+++ b/spec/services/try_user_transition_from_registered_service_spec.rb
@@ -35,8 +35,9 @@ RSpec.describe 'TryUserTransitionFromRegisteredService' do
 
     context 'The user has insufficient PRs and Hacktoberfest has ended' do
       before do
-        travel_to Time.zone.parse(ENV['END_DATE']) + 1.day
         pr_stub_helper(user, PR_DATA[:mature_array][0...3])
+        user.pull_requests # Ensure they're in the DB before the time change
+        travel_to Time.zone.parse(ENV['END_DATE']) + 1.day
         TryUserTransitionFromRegisteredService.call(user)
       end
 

--- a/spec/support/pull_request_filter_helper.rb
+++ b/spec/support/pull_request_filter_helper.rb
@@ -695,7 +695,6 @@ module PullRequestFilterHelper
     allow(target.send(:pull_request_service))
       .to receive(:github_pull_requests)
       .and_return(pull_request_data(pr_data))
-    target.pull_requests
   end
 
   class << self

--- a/spec/support/pull_request_filter_helper.rb
+++ b/spec/support/pull_request_filter_helper.rb
@@ -695,6 +695,7 @@ module PullRequestFilterHelper
     allow(target.send(:pull_request_service))
       .to receive(:github_pull_requests)
       .and_return(pull_request_data(pr_data))
+    target.pull_requests
   end
 
   class << self


### PR DESCRIPTION
# Description

If a PR was created more than 14 days ago on GitHub, without being opted-in -- thus in an invalid state -- and was then opted-in, the PR would not be able to transition to a valid state.

It could not transition to the waiting state, as it passed the app's old review period check, but could also not enter the eligible state as this is locked behind being in the waiting state.

The simple fix here is to ensure that all PRs go through the waiting state (there is already duplicated logic that handles brand new PRs having their waiting since set to their creation date), before they ever enter the eligible state.

# Test process

- Have a PR created on GitHub more than 14 days ago
- Ensure the PR is not opted-in to Hacktoberfest
- Sign up and register with the app locally
- Observe the PR shows in an invalid state
- Opt the PR in
- Refresh the profile, the PR should show in the waiting state with 14 days remaining

---

- Have a PR created on GitHub more than 14 days ago
- Ensure the PR is opted-in to Hacktoberfest
- Sign up and register with the app locally
- Observe the PR shows immediately as eligible

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
