### PR TITLE
Restrict all jobs to run only during the month of October.

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -20,7 +20,7 @@
     queue: default
     description: 'This job updates issues for quality standards every day at 5AM'
   :ban_all_repos:
-    cron: 0 */1 * 9-11 *
+    cron: '0 */1 * 9-11 * America/New_York'
     class: BanAllReposJob
     queue: default
     description: 'Ban repos every hour'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,32 +5,32 @@
 
 :schedule:
   :transition_all_users:
-    cron: '0 */2 * 10 * America/New_York'
+    cron: '0 */2 * 9-11 * America/New_York'
     class: TransitionAllUsersJob
     queue: critical
     description: 'This job transitions users every two hours'
   :update_all_issues:
-    cron: '0 3 * 10 * America/New_York'
+    cron: '0 3 * 9-11 * America/New_York'
     class: UpdateAllIssuesJob
     queue: critical
     description: 'This job updates all issues every day at 3AM'
   :update_all_issues_quality:
-    cron: '0 5 * 10 * America/New_York'
+    cron: '0 5 * 9-11 * America/New_York'
     class: UpdateAllIssuesQualityJob
     queue: default
     description: 'This job updates issues for quality standards every day at 5AM'
   :ban_all_repos:
-    cron: 0 */1 * 10 *
+    cron: 0 */1 * 9-11 *
     class: BanAllReposJob
     queue: default
     description: 'Ban repos every hour'
   :fetch_spam_repositories:
-    cron: '*/15 * * 10 * America/New_York'
+    cron: '*/15 * * 9-11 * America/New_York'
     class: FetchSpamRepositoriesJob
     queue: default
     description: 'Updates spam repos every 15 minutes'
   :homepage_project_import:
-    cron: '0 1 */3 10 * America/New_York'
+    cron: '0 1 */3 9-11 * America/New_York'
     class: ProjectImportJob
     queue: default
     description: 'Updates the projects displayed on the homepage every day at 1AM'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,32 +5,32 @@
 
 :schedule:
   :transition_all_users:
-    cron: '0 */2 * * * America/New_York'
+    cron: '0 */2 * 10 * America/New_York'
     class: TransitionAllUsersJob
     queue: critical
     description: 'This job transitions users every two hours'
   :update_all_issues:
-    cron: '0 3 * * * America/New_York'
+    cron: '0 3 * 10 * America/New_York'
     class: UpdateAllIssuesJob
     queue: critical
     description: 'This job updates all issues every day at 3AM'
   :update_all_issues_quality:
-    cron: '0 5 * * * America/New_York'
+    cron: '0 5 * 10 * America/New_York'
     class: UpdateAllIssuesQualityJob
     queue: default
     description: 'This job updates issues for quality standards every day at 5AM'
   :ban_all_repos:
-    every: ['1h']
+    cron: 0 */1 * 10 *
     class: BanAllReposJob
     queue: default
     description: 'Ban repos every hour'
   :fetch_spam_repositories:
-    cron: '*/15 * * * * America/New_York'
+    cron: '*/15 * * 10 * America/New_York'
     class: FetchSpamRepositoriesJob
     queue: default
     description: 'Updates spam repos every 15 minutes'
   :homepage_project_import:
-    cron: '0 1 */3 * * America/New_York'
+    cron: '0 1 */3 10 * America/New_York'
     class: ProjectImportJob
     queue: default
     description: 'Updates the projects displayed on the homepage every day at 1AM'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -33,4 +33,4 @@
     cron: '0 1 */3 9-11 * America/New_York'
     class: ProjectImportJob
     queue: default
-    description: 'Updates the projects displayed on the homepage every day at 1AM'
+    description: 'Updates the projects displayed on the homepage every three days at 1AM'


### PR DESCRIPTION
# Description
This PR is meant to close issue #435. It restricts all jobs in the sidekiq schedule to the month of October. This will effectively stop all jobs when Hacktoberfest is over. It happens automatically (no manual work), and it can be used again in subsequent years without any code changes. 

# Test process
I have not tested this, beyond confirming the crons in a cron generator. I'm not sure how. I suppose it could be tested in a QA environment by changing the system time, or the month of the cron, but I'll leave that up to maintainers to decide.

# Requirements to merge
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [X] My changes generate no new warnings
- [NA] I have added tests that prove my fix is effective or that my feature works
- [NA] New and existing unit tests pass locally with my changes
