### PR TITLE
Don't check waiting since on waiting transition

### DIFF
--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -44,7 +44,6 @@ class PullRequest < ApplicationRecord
       transition all - %i[eligible] => :waiting,
                  if: lambda { |pr|
                        !pr.hacktoberfest_ended? &&
-                         !pr.passed_review_period? &&
                          !pr.spammy? &&
                          !pr.labelled_invalid? &&
                          pr.in_topic_repo? &&

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
 class PullRequest < ApplicationRecord
   attr_reader :github_pull_request
 
@@ -137,4 +136,3 @@ class PullRequest < ApplicationRecord
     pr
   end
 end
-# rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
# Description

If a PR was previously in the waiting state, with a waiting_since date over 14 days ago, and was then made invalid (opted-out), before then being made valid again the PR would not be able to transition back to waiting.

This was because we checked the old waiting since date when transitioning to waiting. This PR removes that check, allowing a PR of any age to enter the waiting state, resetting the waiting since timer.

# Test process

- Have a invalid PR
- Manually set the waiting since date in the database to a date more than 14 days ago
- Make the PR valid
- Reload profile
- Observe PR transitions to waiting state with updated waiting since date

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
