### PR TITLE
Add message if wistia fails to load

### DIFF
--- a/app/assets/stylesheets/register.scss
+++ b/app/assets/stylesheets/register.scss
@@ -152,6 +152,20 @@ section.reg-content {
           background-color: $pink;
         }
       }
+
+      .beginners-video {
+        position: relative;
+
+        &:before {
+          content: "Video not loading? Ensure that you have disabled any adblockers or privacy shields that may block *.wistia.com from loading.\00000a\00000aProblem persisting? Send us an email: hacktoberfest@digitalocean.com";
+          white-space: pre-wrap;
+          position: absolute;
+          top: 50%;
+          transform: translateY(-50%);
+          width: 100%;
+          text-align: center;
+        }
+      }
     }
 
     .registration-right {

--- a/app/assets/stylesheets/register.scss
+++ b/app/assets/stylesheets/register.scss
@@ -157,7 +157,7 @@ section.reg-content {
         position: relative;
 
         &:before {
-          content: "Video not loading? Ensure that you have disabled any adblockers or privacy shields that may block *.wistia.com from loading.\00000a\00000aProblem persisting? Send us an email: hacktoberfest@digitalocean.com";
+          content: "Video not loading? Ensure that you have disabled any adblockers or privacy shields that may prevent *.wistia.com from loading.\00000a\00000aProblem persisting? Send us an email: hacktoberfest@digitalocean.com";
           white-space: pre-wrap;
           position: absolute;
           top: 50%;


### PR DESCRIPTION
# Description

I could not get to the bottom of what exactly causes Wistia to fail to load, seems user-specific. Instead, I've added messaging that'll show if Wistia doesn't load, letting folks know to check for common things that might be blocking it, plus a pointer to support if it persists.

![image](https://user-images.githubusercontent.com/12371363/97209104-d5e3e800-17b3-11eb-871c-ae602492bef2.png)

# Test process

- Block wisita.com on Hacktoberfest (using privacy badger for example)
- Go through registration, observe messaging displayed

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
