### PR TITLE
Include repo topics and app data in exported metadata

### DIFF
--- a/app/services/import_one_pr_metadata_service.rb
+++ b/app/services/import_one_pr_metadata_service.rb
@@ -5,6 +5,7 @@ module ImportOnePrMetadataService
 
   def call(url)
     pr_data = client.pull_request(*pull_request_args_from_url(url)).to_hash
+    pr_data[:app] = PullRequest.find_by(gh_id: pr_data[:node_id]).as_json
 
     # using node_id here because that's what we
     # used previously as the pr_id in a PRStat. This way the data is consistent

--- a/app/services/import_repo_metadata_service.rb
+++ b/app/services/import_repo_metadata_service.rb
@@ -8,6 +8,7 @@ module ImportRepoMetadataService
     api_client = Octokit::Client.new(access_token: access_token)
 
     repo = api_client.repo(repo_id).to_hash
+    repo[:topics] = api_client.topics(repo_id).to_hash
     repo_stat = RepoStat.where(repo_id: repo_id).first_or_create(data: repo)
     repo_stat.update(data: repo)
   end

--- a/app/services/import_user_metadata_service.rb
+++ b/app/services/import_user_metadata_service.rb
@@ -10,6 +10,7 @@ module ImportUserMetadataService
     api_client = Octokit::Client.new(access_token: access_token)
 
     user_data = api_client.user(user.uid).to_hash
+    user_data[:app] = user.as_json.except('provider_token')
 
     user_stat = UserStat.where(user_id: user.id)
                         .first_or_create(data: user_data)

--- a/lib/tasks/stats_to_json.rake
+++ b/lib/tasks/stats_to_json.rake
@@ -1,18 +1,39 @@
 # frozen_string_literal: true
 
+def custom_database_connection
+  return unless ENV['HACKTOBERFEST_DATABASE_CUSTOM']
+
+  # Support modifying the DB connection to allow remote export.
+  # Setting these env vars without this method works fine,
+  #  except the vars that need casting to integers.
+  conn_config = ActiveRecord::Base.connection_config
+  conn_config[:database] = ENV['HACKTOBERFEST_DATABASE_NAME']
+  conn_config[:username] = ENV['HACKTOBERFEST_DATABASE_USERNAME']
+  conn_config[:password] = ENV['HACKTOBERFEST_DATABASE_PASSWORD']
+  conn_config[:host] = ENV['HACKTOBERFEST_DATABASE_HOST']
+  conn_config[:port] = ENV['HACKTOBERFEST_DATABASE_PORT']&.to_i
+  conn_config[:pool] = ENV['HACKTOBERFEST_DATABASE_POOL_SIZE']&.to_i
+  conn_config[:timeout] = ENV['HACKTOBERFEST_DATABASE_TIMEOUT']&.to_i
+  ActiveRecord::Base.establish_connection conn_config
+  p conn_config
+end
+
 namespace :export do
   desc 'Export all UserStats to a JSON file'
   task user_stats: :environment do
+    custom_database_connection
     JsonForUserStatsService.call
   end
 
   desc 'Export all PRStats to a JSON file'
   task pr_stats: :environment do
+    custom_database_connection
     JsonForPrStatsService.call
   end
 
   desc 'Export all RepoStats to a JSON file'
   task repo_stats: :environment do
+    custom_database_connection
     JsonForRepoStatsService.call
   end
 end

--- a/spec/services/import_one_pr_metadata_service_spec.rb
+++ b/spec/services/import_one_pr_metadata_service_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ImportOnePrMetadataService do
 
         it 'updates the existing pr stat' do
           expect(PRStat.first.data).to eq(
-            'node_id' => 'test', 'data' => 'updated-data'
+            'node_id' => 'test', 'data' => 'updated-data', 'app' => nil
           )
         end
       end

--- a/spec/services/import_repo_metadata_service_spec.rb
+++ b/spec/services/import_repo_metadata_service_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe ImportRepoMetadataService do
       before do
         allow_any_instance_of(Octokit::Client)
           .to receive(:repo).and_return("test": 1)
+        allow_any_instance_of(Octokit::Client)
+          .to receive(:topics).and_return("test": 1)
       end
 
       it 'creates one repostat' do
@@ -27,7 +29,8 @@ RSpec.describe ImportRepoMetadataService do
       it 'creates a repostat with the correct data' do
         ImportRepoMetadataService.call(1)
 
-        expect(RepoStat.last.data).to eq('test' => 1)
+        expect(RepoStat.last.data)
+          .to eq('test' => 1, 'topics' => { 'test' => 1 })
       end
     end
 
@@ -35,8 +38,11 @@ RSpec.describe ImportRepoMetadataService do
       before do
         allow_any_instance_of(Octokit::Client)
           .to receive(:repo).and_return("test": 2)
+        allow_any_instance_of(Octokit::Client)
+          .to receive(:topics).and_return("test": 2)
 
-        RepoStat.create(repo_id: 1, data: { "test": 1 })
+        RepoStat.create(repo_id: 1,
+                        data: { "test": 1, "topics": { "test": 1 } })
       end
 
       it 'does not create a new repostat' do
@@ -48,7 +54,8 @@ RSpec.describe ImportRepoMetadataService do
       it 'updates the repostat' do
         ImportRepoMetadataService.call(1)
 
-        expect(RepoStat.last.data).to eq('test' => 2)
+        expect(RepoStat.last.data)
+          .to eq('test' => 2, 'topics' => { 'test' => 2 })
       end
     end
   end

--- a/spec/services/import_user_metadata_service_spec.rb
+++ b/spec/services/import_user_metadata_service_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe ImportUserMetadataService do
         it 'updates the UserStat' do
           ImportUserMetadataService.call(user)
 
-          expect(UserStat.last.data).to eq('test' => 1)
+          # This data also has serialized user data which we're not testing
+          expect(UserStat.last.data['test']).to eq(1)
         end
       end
     end


### PR DESCRIPTION
# Description

Update the GitHub scraping logic to include all topics a repo has, as well as the app data for PRs & users.

Adding the custom DB logic to the export allows a dev to remotely export the final JSON on their local device, connecting to the remote prod/staging DB.

E.g. `docker-compose exec -e HACKTOBERFEST_DATABASE_HOST=the.hacktoberfest.staging.fqdn -e HACKTOBERFEST_DATABASE_PORT=12345 -e HACKTOBERFEST_DATABASE_NAME=default -e HACKTOBERFEST_DATABASE_USERNAME=dodge -e HACKTOBERFEST_DATABASE_PASSWORD=hunter2 -e HACKTOBERFEST_DATABASE_TIMEOUT=10 -e HACKTOBERFEST_DATABASE_CUSTOM=1 app bundle exec rake export:user_stats`

# Test process

- `bundle exec rake github:import_metadata`
- Allow time for jobs to run
- Check `data` entries in `repo_stats` table, should include `topics` key
- Check `data` entries in `pr_stats` table, should include `app` key
- Check `data` entries in `user_stats` table, should include `app` key

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
