### PR TITLE
Preserve topic repos

### DIFF
--- a/app/models/preserved_topic_pr.rb
+++ b/app/models/preserved_topic_pr.rb
@@ -2,6 +2,10 @@
 
 class PreservedTopicPR < ApplicationRecord
   # Maintainers are removing topics from their repos before PRs can mature
-  # This holds all waiting PRs as of Oct 31. so they can bypass the topic check
+  # This holds all waiting PRs as of Oct. 31st so they can bypass the topic check
   validates :pr_id, presence: true, uniqueness: true
+
+  def self.has?(pr_id)
+    self.find_by(pr_id: pr_id).present?
+  end
 end

--- a/app/models/preserved_topic_pr.rb
+++ b/app/models/preserved_topic_pr.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PreservedTopicPR < ApplicationRecord
+  # Maintainers are removing topics from their repos before PRs can mature
+  # This holds all waiting PRs as of Oct 31. so they can bypass the topic check
+  validates :pr_id, presence: true, uniqueness: true
+end

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -105,6 +105,9 @@ class PullRequest < ApplicationRecord
     # PR-specific opt-in
     return true if labelled_accepted?
 
+    # Handle maintainers removing the topic after Oct. 31st
+    return true if PreservedTopicPR.has?(github_id)
+
     repository_topics.select { |topic| topic.strip == 'hacktoberfest' }.any?
   end
 

--- a/db/migrate/20201102184444_create_preserved_topic_prs.rb
+++ b/db/migrate/20201102184444_create_preserved_topic_prs.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CreatePreservedTopicPrs < ActiveRecord::Migration[5.2]
+  def change
+    create_table :preserved_topic_prs do |t|
+      t.string :pr_id, unique: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_02_195525) do
+ActiveRecord::Schema.define(version: 2020_11_02_184444) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,12 @@ ActiveRecord::Schema.define(version: 2020_10_02_195525) do
 
   create_table "pr_stats", force: :cascade do |t|
     t.jsonb "data", null: false
+    t.string "pr_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "preserved_topic_prs", force: :cascade do |t|
     t.string "pr_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/lib/tasks/rescue_preserved_topic_prs.rake
+++ b/lib/tasks/rescue_preserved_topic_prs.rake
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+namespace :rescue_preserved_topic_prs do
+  task update_prs: :environment do
+    PreservedTopicPR.find_each do |preserved_pr|
+      pr = PullRequest.find_by(gh_id: preserved_pr.gh_id)
+
+      return unless pr.present?
+      return unless pr.state == 'topic_missing'
+
+      pr.update_attribute('state', 'waiting')
+      pr.update_attribute('waiting_since', pr.waiting_since || (Hacktoberfest.end_date - 1.minute))
+    end
+  end
+
+  task update_users: :environment do
+    User.find_each do |user|
+      # If the user was affected and it caused them to lose, reset them
+      if user.incompleted? && user.any_waiting_prs?
+        if user.sufficient_waiting_or_eligible_prs?
+          user.update_attribute('state', 'waiting')
+          user.update_attribute('waiting_since', user.pull_request_service.waiting_prs.map(&:waiting_since).sort[3 - user.eligible_pull_requests_count])
+        else
+          user.update_attribute('state', 'registered')
+        end
+        user.update_attribute('receipt', nil)
+        SegmentService.new(user).identify(state: user.state)
+      end
+
+      # Touch the PRs to ensure Segment is correct
+      user.pull_requests
+
+      # Try transitioning the user
+      TryUserTransitionService.call(user)
+    end
+  end
+end


### PR DESCRIPTION
# Description

Create `PreservedTopicPR` which will contain all PR IDs that were in the `waiting` state prior to Hf ending.

Skip the repository topic check for a PR if it is in the preserved list.

Rake task to restore PRs back into the waiting state if they became invalid due to the topic being removed after Hf ended.

Rake task to restore users back into the correct state if their invalid PRs caused them to lose.

# Test process

This is absolutely untested, good luck.

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
