### PR TITLE
Support multiple API keys

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -22,6 +22,6 @@ class ApiController < ApplicationController
   end
 
   def valid_authentication?
-    request.headers['Authorization'] == ENV.fetch('HACKTOBERFEST_API_KEY')
+    Hacktoberfest.api_keys.include? request.headers['Authorization']&.strip
   end
 end

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -17,7 +17,7 @@ module Hacktoberfest
 
   def api_keys
     @api_keys ||= ENV.fetch('HACKTOBERFEST_API_KEY').split(',').map(&:strip)
-                      .select { |key| key.is_a?(String) && key.length }
+                     .select { |key| key.is_a?(String) && key.length }
   end
 
   def airtable_key_present?

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -15,6 +15,11 @@ module Hacktoberfest
     @rules_date ||= Time.parse(ENV.fetch('RULES_DATE')).utc
   end
 
+  def api_keys
+    @api_keys ||= ENV.fetch('HACKTOBERFEST_API_KEY').split(',').map(&:strip)
+                      .select { |key| key.is_a?(String) && key.length }
+  end
+
   def airtable_key_present?
     ENV.fetch('AIRTABLE_API_KEY', nil).present?
   end


### PR DESCRIPTION
# Description

Support multiple comma-separated API keys

# Test process

- Set `HACKTOBERFEST_API_KEY=this_is_a_secret,this_is_another,`
- Confirm accessing the API with no auth header fails
- Confirm accessing the API with auth header as `aaaaa` fails
- Confirm accessing the API with auth header as `this_is_a_secret` works
- Confirm accessing the API with auth header as `this_is_another` works

# Requirements to merge

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
